### PR TITLE
add fix for mac execName " Helper" issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-wdio": "^7.4.2",
     "husky": "^7.0.4",
     "jest": "^27.4.7",
-    "lint-staged": "^12.1.5",
+    "lint-staged": "^12.1.7",
     "prettier": "^2.5.1",
     "release-it": "^14.11.8",
     "ts-jest": "^27.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ specifiers:
   eslint-plugin-wdio: ^7.4.2
   husky: ^7.0.4
   jest: ^27.4.7
-  lint-staged: ^12.1.5
+  lint-staged: ^12.1.7
   prettier: ^2.5.1
   release-it: ^14.11.8
   ts-jest: ^27.1.2
@@ -60,7 +60,7 @@ devDependencies:
   eslint-plugin-wdio: 7.4.2
   husky: 7.0.4
   jest: 27.4.7
-  lint-staged: 12.1.5
+  lint-staged: 12.1.7
   prettier: 2.5.1
   release-it: 14.11.8
   ts-jest: 27.1.2_9364f2ad0b7b67f00a4d081c662c6871
@@ -4350,8 +4350,8 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
-  /lint-staged/12.1.5:
-    resolution: {integrity: sha512-WyKb+0sNKDTd1LwwAfTBPp0XmdaKkAOEbg4oHE4Kq2+oQVchg/VAcjVQtSqZih1izNsTURjc2EkhG/syRQUXdA==}
+  /lint-staged/12.1.7:
+    resolution: {integrity: sha512-bltv/ejiLWtowExpjU+s5z8j1Byjg9AlmaAjMmqNbIicY69u6sYIwXGg0dCn0TlkrrY2CphtHIXAkbZ+1VoWQQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
     dependencies:

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,6 +1,11 @@
 import { Capabilities, Options, Services } from '@wdio/types';
 import { isCI } from 'ci-info';
 
+function getMacExecutableName(appName: string) {
+  // https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/src/macPackager.ts#L390
+  return appName.endsWith(' Helper') ? appName.replace(' Helper', '') : appName;
+}
+
 function getBinaryPath(distPath: string, appName: string) {
   const SupportedPlatform = {
     darwin: 'darwin',
@@ -14,7 +19,7 @@ function getBinaryPath(distPath: string, appName: string) {
   }
 
   const pathMap = {
-    darwin: `mac/${appName}.app/Contents/MacOS/${appName}`,
+    darwin: `mac/${appName}.app/Contents/MacOS/${getMacExecutableName(appName)}`,
     linux: `linux-unpacked/${appName}`,
     win32: `win-unpacked/${appName}.exe`,
   };

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -159,6 +159,23 @@ describe('beforeSession', () => {
           },
         });
       });
+
+      it('should set the expected capabilities when the appName ends with "Helper"', () => {
+        instance = new WorkerService({
+          appPath: 'workspace/my-test-app/dist',
+          appName: 'My Test Helper',
+        });
+        const capabilities = {};
+        instance.beforeSession({}, capabilities);
+        expect(capabilities).toEqual({
+          'browserName': 'chrome',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/mac/My Test Helper.app/Contents/MacOS/My Test',
+            windowTypes: ['app', 'webview'],
+          },
+        });
+      });
     });
 
     describe('on MacOS platforms running on CI', () => {


### PR DESCRIPTION
It turns out that app names which end with " Helper" cause crashes on MacOS. `electron-builder` has worked around this by stripping " Helper" for the executable name only (CFBundleExecutable). I wouldn't have noticed had my Electron app not been named "DJ Helper".  Just replicating the `electron-builder` behaviour here.