### PR TITLE
Node 12 Support

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -134,7 +134,7 @@ export default class ElectronWorkerService implements Services.ServiceInstance {
       !Array.isArray(capabilities) &&
       Object.keys(capabilities).length > 0 &&
       Object.values(capabilities).every((cap) => typeof cap === 'object');
-    const isElectron = (cap: Capabilities.Capabilities) => cap?.browserName?.toLowerCase() === 'electron';
+    const isElectron = (cap: Capabilities.Capabilities) => cap && cap.browserName && cap.browserName.toLowerCase() === 'electron';
 
     if (isMultiremote) {
       Object.values(capabilities).forEach((cap: { capabilities: Capabilities.Capabilities }) => {


### PR DESCRIPTION
WDIO supports v12.16.1 and beyond. wdio-electron-service requires node 14+ for the null coalesce operator. This change re-writes the check that uses it and allows wdio-electron-service to be used for all node versions that WDIO supports.
