### PR TITLE
(docs): add docs to the typescript API

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test:integration:cjs": "cd example-cjs && pnpm run ci",
     "test:integration:esm": "cd example && pnpm run ci",
     "update:all": "pnpm --filter=\\!fixture-\\* up -iL",
-    "watch": "pnpm run build:esm -- --watch"
+    "watch": "pnpm run build:esm --watch"
   },
   "keywords": [
     "webdriverio",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,103 @@ export const launcher = ElectronLaunchService;
 export default ElectronWorkerService;
 export interface BrowserExtension {
   electron: {
-    api: (...arg: unknown[]) => Promise<unknown>;
+    /**
+     * Call a custom handler within the Electron process.
+     * @param args arbitrary arguments to pass to the handler
+     * @returns a {@link Promise} that resolves once the handler was triggered
+     * 
+     * @example
+     * ```js
+     * // in your Electron main process file
+     * const { ipcMain } = require('electron');
+     * ipcMain.handle('wdio-electron', (event, ...args) => {
+     *   // ...
+     *   return 'some result';
+     * });
+     * 
+     * // in your test file
+     * const result = await browser.electron.api()
+     * console.log(result) // 'some result'
+     * ```
+     */
+    api: (...args: unknown[]) => Promise<unknown>;
+    /**
+     * Access the Electron {@link https://www.electronjs.org/docs/latest/api/app app} API and call function through the command.
+     * @param funcName name of the function from the `app` interface
+     * @param arg      arguments to pass to the function
+     * @returns a {@link Promise} that resolves to the return value of the function
+     *
+     * @example
+     * ```js
+     * // get the app's name
+     * const appName = await browser.electron.app('getName');
+     * // 'My App'
+     * console.log(appName)
+     * ```
+     */
     app: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
+    /**
+     * Access the Electron {@link https://www.electronjs.org/docs/latest/api/browser-window browserWindow} API and call function through the command.
+     * @param funcName name of the function from the `browserWindow` interface
+     * @param arg      arguments to pass to the function
+     * @returns a {@link Promise} that resolves to the return value of the function
+     *
+     * @example
+     * ```js
+     * // get the current window's bounds
+     * const bounds = await browser.electron.browserWindow('getBounds');
+     * // { x: 440, y: 225, width: 100, height: 600 }
+     * console.log(bounds)
+     * ```
+     */
     browserWindow: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
+    /**
+     * Access the Electron {@link https://www.electronjs.org/docs/latest/api/dialog dialog} API and call function through the command.
+     * @param funcName name of the function from the `dialog` interface
+     * @param arg      arguments to pass to the function
+     * @returns a {@link Promise} that resolves to the return value of the function
+     *
+     * @example
+     * ```js
+     * // show a message box
+     * await browser.electron.dialog('showMessageBox', {
+     *   type: 'info',
+     *   buttons: ['Ok'],
+     *   message: 'Hello World',
+     * });
+     * ```
+     */
     dialog: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
+    /**
+     * Access the Electron {@link https://www.electronjs.org/docs/latest/api/process process} API and call function through the command.
+     * @param funcName name of the function from the `mainProcess` interface
+     * @param arg      arguments to pass to the function
+     * @returns a {@link Promise} that resolves to the return value of the function
+     *
+     * @example
+     * ```js
+     * // get the current process's pid
+     * const pid = await browser.electron.mainProcess('getProcessId');
+     * // 1234
+     * console.log(pid)
+     * ```
+     */
     mainProcess: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
+    /**
+     * Mock a function from the Electron API.
+     * @param apiName name of the API to mock
+     * @param funcName name of the function to mock
+     * @param mockReturnValue value to return when the mocked function is called
+     * @returns a {@link Promise} that resolves once the mock is registered
+     *
+     * @example
+     * ```js
+     * // mock the app's getName function
+     * await browser.electron.mock('dialog', 'showOpenDialog', 'I opened a dialog!');
+     * const result = await browser.electron.dialog('showOpenDialog');
+     * expect(result).toEqual('I opened a dialog!');
+     * ```
+     */
     mock: (apiName: string, funcName: string, mockReturnValue: unknown) => Promise<unknown> | unknown;
   };
 }
@@ -31,6 +123,9 @@ declare global {
     interface Browser extends BrowserExtension {}
     interface MultiRemoteBrowser extends BrowserExtension {}
     interface Capabilities {
+      /**
+       * custom capabilities to configure the Electron service
+       */
       'wdio:electronServiceOptions'?: ElectronServiceOptions;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ interface ElectronServiceAPI {
    * Call a custom handler within the Electron process.
    * @param args arbitrary arguments to pass to the handler
    * @returns a {@link Promise} that resolves once the handler was triggered
-   * 
+   *
    * @example
    * ```js
    * // in your Electron main process file
@@ -24,7 +24,7 @@ interface ElectronServiceAPI {
    *   // ...
    *   return 'some result';
    * });
-   * 
+   *
    * // in your test file
    * const result = await browser.electron.api()
    * console.log(result) // 'some result'
@@ -109,12 +109,12 @@ interface ElectronServiceAPI {
    * ```
    */
   mock: (apiName: string, funcName: string, mockReturnValue: unknown) => Promise<unknown> | unknown;
-};
+}
 
 export interface BrowserExtension {
   /**
    * Access the WebdriverIO Electron Service API.
-   * 
+   *
    * - {@link ElectronServiceAPI.api `browser.electron.api`} - Call a custom handler within the Electron process.
    * - {@link ElectronServiceAPI.app `browser.electron.app`} - Access the Electron {@link https://www.electronjs.org/docs/latest/api/app app} API and call function through the command.
    * - {@link ElectronServiceAPI.browserWindow `browser.electron.browserWindow`} - Access the Electron {@link https://www.electronjs.org/docs/latest/api/browser-window browserWindow} API and call function through the command.
@@ -122,7 +122,7 @@ export interface BrowserExtension {
    * - {@link ElectronServiceAPI.mainProcess `browser.electron.mainProcess`} - Access the Electron {@link https://www.electronjs.org/docs/latest/api/process process} API and call function through the command.
    * - {@link ElectronServiceAPI.mock `browser.electron.mock`} - Mock a function from the Electron API.
    */
-  electron: ElectronServiceAPI
+  electron: ElectronServiceAPI;
 }
 
 type WdioElectronWindowObj = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,107 +9,120 @@ process.env.WDIO_ELECTRON = 'true';
 
 export const launcher = ElectronLaunchService;
 export default ElectronWorkerService;
+
+interface ElectronServiceAPI {
+  /**
+   * Call a custom handler within the Electron process.
+   * @param args arbitrary arguments to pass to the handler
+   * @returns a {@link Promise} that resolves once the handler was triggered
+   * 
+   * @example
+   * ```js
+   * // in your Electron main process file
+   * const { ipcMain } = require('electron');
+   * ipcMain.handle('wdio-electron', (event, ...args) => {
+   *   // ...
+   *   return 'some result';
+   * });
+   * 
+   * // in your test file
+   * const result = await browser.electron.api()
+   * console.log(result) // 'some result'
+   * ```
+   */
+  api: (...args: unknown[]) => Promise<unknown>;
+  /**
+   * Access the Electron {@link https://www.electronjs.org/docs/latest/api/app app} API and call function through the command.
+   * @param funcName name of the function from the `app` interface
+   * @param arg      arguments to pass to the function
+   * @returns a {@link Promise} that resolves to the return value of the function
+   *
+   * @example
+   * ```js
+   * // get the app's name
+   * const appName = await browser.electron.app('getName');
+   * // 'My App'
+   * console.log(appName)
+   * ```
+   */
+  app: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
+  /**
+   * Access the Electron {@link https://www.electronjs.org/docs/latest/api/browser-window browserWindow} API and call function through the command.
+   * @param funcName name of the function from the `browserWindow` interface
+   * @param arg      arguments to pass to the function
+   * @returns a {@link Promise} that resolves to the return value of the function
+   *
+   * @example
+   * ```js
+   * // get the current window's bounds
+   * const bounds = await browser.electron.browserWindow('getBounds');
+   * // { x: 440, y: 225, width: 100, height: 600 }
+   * console.log(bounds)
+   * ```
+   */
+  browserWindow: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
+  /**
+   * Access the Electron {@link https://www.electronjs.org/docs/latest/api/dialog dialog} API and call function through the command.
+   * @param funcName name of the function from the `dialog` interface
+   * @param arg      arguments to pass to the function
+   * @returns a {@link Promise} that resolves to the return value of the function
+   *
+   * @example
+   * ```js
+   * // show a message box
+   * await browser.electron.dialog('showMessageBox', {
+   *   type: 'info',
+   *   buttons: ['Ok'],
+   *   message: 'Hello World',
+   * });
+   * ```
+   */
+  dialog: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
+  /**
+   * Access the Electron {@link https://www.electronjs.org/docs/latest/api/process process} API and call function through the command.
+   * @param funcName name of the function from the `mainProcess` interface
+   * @param arg      arguments to pass to the function
+   * @returns a {@link Promise} that resolves to the return value of the function
+   *
+   * @example
+   * ```js
+   * // get the current process's pid
+   * const pid = await browser.electron.mainProcess('getProcessId');
+   * // 1234
+   * console.log(pid)
+   * ```
+   */
+  mainProcess: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
+  /**
+   * Mock a function from the Electron API.
+   * @param apiName name of the API to mock
+   * @param funcName name of the function to mock
+   * @param mockReturnValue value to return when the mocked function is called
+   * @returns a {@link Promise} that resolves once the mock is registered
+   *
+   * @example
+   * ```js
+   * // mock the app's getName function
+   * await browser.electron.mock('dialog', 'showOpenDialog', 'I opened a dialog!');
+   * const result = await browser.electron.dialog('showOpenDialog');
+   * expect(result).toEqual('I opened a dialog!');
+   * ```
+   */
+  mock: (apiName: string, funcName: string, mockReturnValue: unknown) => Promise<unknown> | unknown;
+};
+
 export interface BrowserExtension {
-  electron: {
-    /**
-     * Call a custom handler within the Electron process.
-     * @param args arbitrary arguments to pass to the handler
-     * @returns a {@link Promise} that resolves once the handler was triggered
-     * 
-     * @example
-     * ```js
-     * // in your Electron main process file
-     * const { ipcMain } = require('electron');
-     * ipcMain.handle('wdio-electron', (event, ...args) => {
-     *   // ...
-     *   return 'some result';
-     * });
-     * 
-     * // in your test file
-     * const result = await browser.electron.api()
-     * console.log(result) // 'some result'
-     * ```
-     */
-    api: (...args: unknown[]) => Promise<unknown>;
-    /**
-     * Access the Electron {@link https://www.electronjs.org/docs/latest/api/app app} API and call function through the command.
-     * @param funcName name of the function from the `app` interface
-     * @param arg      arguments to pass to the function
-     * @returns a {@link Promise} that resolves to the return value of the function
-     *
-     * @example
-     * ```js
-     * // get the app's name
-     * const appName = await browser.electron.app('getName');
-     * // 'My App'
-     * console.log(appName)
-     * ```
-     */
-    app: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
-    /**
-     * Access the Electron {@link https://www.electronjs.org/docs/latest/api/browser-window browserWindow} API and call function through the command.
-     * @param funcName name of the function from the `browserWindow` interface
-     * @param arg      arguments to pass to the function
-     * @returns a {@link Promise} that resolves to the return value of the function
-     *
-     * @example
-     * ```js
-     * // get the current window's bounds
-     * const bounds = await browser.electron.browserWindow('getBounds');
-     * // { x: 440, y: 225, width: 100, height: 600 }
-     * console.log(bounds)
-     * ```
-     */
-    browserWindow: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
-    /**
-     * Access the Electron {@link https://www.electronjs.org/docs/latest/api/dialog dialog} API and call function through the command.
-     * @param funcName name of the function from the `dialog` interface
-     * @param arg      arguments to pass to the function
-     * @returns a {@link Promise} that resolves to the return value of the function
-     *
-     * @example
-     * ```js
-     * // show a message box
-     * await browser.electron.dialog('showMessageBox', {
-     *   type: 'info',
-     *   buttons: ['Ok'],
-     *   message: 'Hello World',
-     * });
-     * ```
-     */
-    dialog: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
-    /**
-     * Access the Electron {@link https://www.electronjs.org/docs/latest/api/process process} API and call function through the command.
-     * @param funcName name of the function from the `mainProcess` interface
-     * @param arg      arguments to pass to the function
-     * @returns a {@link Promise} that resolves to the return value of the function
-     *
-     * @example
-     * ```js
-     * // get the current process's pid
-     * const pid = await browser.electron.mainProcess('getProcessId');
-     * // 1234
-     * console.log(pid)
-     * ```
-     */
-    mainProcess: (funcName: string, ...arg: unknown[]) => Promise<unknown>;
-    /**
-     * Mock a function from the Electron API.
-     * @param apiName name of the API to mock
-     * @param funcName name of the function to mock
-     * @param mockReturnValue value to return when the mocked function is called
-     * @returns a {@link Promise} that resolves once the mock is registered
-     *
-     * @example
-     * ```js
-     * // mock the app's getName function
-     * await browser.electron.mock('dialog', 'showOpenDialog', 'I opened a dialog!');
-     * const result = await browser.electron.dialog('showOpenDialog');
-     * expect(result).toEqual('I opened a dialog!');
-     * ```
-     */
-    mock: (apiName: string, funcName: string, mockReturnValue: unknown) => Promise<unknown> | unknown;
-  };
+  /**
+   * Access the WebdriverIO Electron Service API.
+   * 
+   * - {@link ElectronServiceAPI.api `browser.electron.api`} - Call a custom handler within the Electron process.
+   * - {@link ElectronServiceAPI.app `browser.electron.app`} - Access the Electron {@link https://www.electronjs.org/docs/latest/api/app app} API and call function through the command.
+   * - {@link ElectronServiceAPI.browserWindow `browser.electron.browserWindow`} - Access the Electron {@link https://www.electronjs.org/docs/latest/api/browser-window browserWindow} API and call function through the command.
+   * - {@link ElectronServiceAPI.dialog `browser.electron.dialog`} - Access the Electron {@link https://www.electronjs.org/docs/latest/api/dialog dialog} API and call function through the command.
+   * - {@link ElectronServiceAPI.mainProcess `browser.electron.mainProcess`} - Access the Electron {@link https://www.electronjs.org/docs/latest/api/process process} API and call function through the command.
+   * - {@link ElectronServiceAPI.mock `browser.electron.mock`} - Mock a function from the Electron API.
+   */
+  electron: ElectronServiceAPI
 }
 
 type WdioElectronWindowObj = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+/**
+ * The options for the ElectronService.
+ */
 export interface ElectronServiceOptions {
   /**
    * The path to the electron binary of the app for testing.


### PR DESCRIPTION
Improve TypeScript documentation for the `electron` object assigned to `browser`.

<img width="961" alt="Screenshot 2023-10-10 at 6 51 58 PM" src="https://github.com/webdriverio-community/wdio-electron-service/assets/731337/bb3d64c1-99ed-47a2-be1d-91a3775b4821">

<img width="941" alt="Screenshot 2023-10-10 at 6 42 44 PM" src="https://github.com/webdriverio-community/wdio-electron-service/assets/731337/672c792b-8876-4c2f-8364-d35087b0cb24">
