### PR TITLE
(feat): support multiremote

### DIFF
--- a/example/multiremote/api.spec.ts
+++ b/example/multiremote/api.spec.ts
@@ -1,3 +1,4 @@
+/// <reference types="@wdio/globals/types" />
 import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
@@ -7,13 +8,20 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), { encoding: 'utf-8' }));
 const { name, version } = packageJson;
 
-describe('electron APIs', () => {
-    describe('app', () => {
-      it('should retrieve app metadata through the electron API', async () => {
+describe('Electron APIs using Multiremote', () => {
+    it('should retrieve app metadata through the electron API', async () => {
         const appName = await multiremotebrowser.electron.app('getName');
         expect(appName).toEqual([name, name]);
         const appVersion = await multiremotebrowser.electron.app('getVersion');
         expect(appVersion).toEqual([version, version]);
-      });
     });
+
+    it('should allow to retrieve API values from single instance', async () => {
+        const browserA = multiremotebrowser.getInstance('browserA');
+        expect(await browserA.electron.app('getName')).toBe(name);
+        expect(await browserA.electron.app('getVersion')).toBe(version);
+        const browserB = multiremotebrowser.getInstance('browserB');
+        expect(await browserB.electron.app('getName')).toBe(name);
+        expect(await browserB.electron.app('getVersion')).toBe(version);
+    })
 });

--- a/example/multiremote/api.spec.ts
+++ b/example/multiremote/api.spec.ts
@@ -2,26 +2,26 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
-import { multiremotebrowser, expect } from "@wdio/globals";
+import { multiremotebrowser, expect } from '@wdio/globals';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), { encoding: 'utf-8' }));
 const { name, version } = packageJson;
 
 describe('Electron APIs using Multiremote', () => {
-    it('should retrieve app metadata through the electron API', async () => {
-        const appName = await multiremotebrowser.electron.app('getName');
-        expect(appName).toEqual([name, name]);
-        const appVersion = await multiremotebrowser.electron.app('getVersion');
-        expect(appVersion).toEqual([version, version]);
-    });
+  it('should retrieve app metadata through the electron API', async () => {
+    const appName = await multiremotebrowser.electron.app('getName');
+    expect(appName).toEqual([name, name]);
+    const appVersion = await multiremotebrowser.electron.app('getVersion');
+    expect(appVersion).toEqual([version, version]);
+  });
 
-    it('should allow to retrieve API values from single instance', async () => {
-        const browserA = multiremotebrowser.getInstance('browserA');
-        expect(await browserA.electron.app('getName')).toBe(name);
-        expect(await browserA.electron.app('getVersion')).toBe(version);
-        const browserB = multiremotebrowser.getInstance('browserB');
-        expect(await browserB.electron.app('getName')).toBe(name);
-        expect(await browserB.electron.app('getVersion')).toBe(version);
-    })
+  it('should allow to retrieve API values from single instance', async () => {
+    const browserA = multiremotebrowser.getInstance('browserA');
+    expect(await browserA.electron.app('getName')).toBe(name);
+    expect(await browserA.electron.app('getVersion')).toBe(version);
+    const browserB = multiremotebrowser.getInstance('browserB');
+    expect(await browserB.electron.app('getName')).toBe(name);
+    expect(await browserB.electron.app('getVersion')).toBe(version);
+  });
 });

--- a/example/multiremote/api.spec.ts
+++ b/example/multiremote/api.spec.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { multiremotebrowser, expect } from "@wdio/globals";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), { encoding: 'utf-8' }));
+const { name, version } = packageJson;
+
+describe('electron APIs', () => {
+    describe('app', () => {
+      it('should retrieve app metadata through the electron API', async () => {
+        const appName = await multiremotebrowser.electron.app('getName');
+        expect(appName).toEqual([name, name]);
+        const appVersion = await multiremotebrowser.electron.app('getVersion');
+        expect(appVersion).toEqual([version, version]);
+      });
+    });
+});

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,8 @@
     "ci": "pnpm i && pnpm build && pnpm test",
     "clean": "pnpm clean:dist && rm -rf ./node_modules pnpm-lock.yaml ./all-logs",
     "clean:dist": "pnpx rimraf ./dist && mkdir -p ./dist",
-    "test": "wdio run ./wdio.conf.ts"
+    "test": "wdio run ./wdio.conf.ts",
+    "test:multiremote": "wdio run ./wdio.multiremote.conf.ts"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.4",

--- a/example/wdio.conf.ts
+++ b/example/wdio.conf.ts
@@ -1,16 +1,18 @@
-/// <reference types="../@types/wdio-electron-service/utils.d.ts" />
+/// <reference types="../dist/index.d.ts" />
+
 import url from 'node:url';
 import path from 'node:path';
+import type { Options } from '@wdio/types';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 process.env.TEST = 'true';
 
-export const config = {
+export const config: Options.Testrunner = {
   services: ['electron'],
   capabilities: [
     {
-      'browserName': 'electron',
+      browserName: 'electron',
       'wdio:electronServiceOptions': {
         appArgs: ['foo', 'bar=baz'],
       },
@@ -26,7 +28,6 @@ export const config = {
   autoCompileOpts: {
     autoCompile: true,
     tsNodeOpts: {
-      esm: true,
       transpileOnly: true,
       files: true,
       project: path.join(__dirname, 'tsconfig.json'),

--- a/example/wdio.conf.ts
+++ b/example/wdio.conf.ts
@@ -12,7 +12,7 @@ export const config: Options.Testrunner = {
   services: ['electron'],
   capabilities: [
     {
-      browserName: 'electron',
+      'browserName': 'electron',
       'wdio:electronServiceOptions': {
         appArgs: ['foo', 'bar=baz'],
       },

--- a/example/wdio.multiremote.conf.ts
+++ b/example/wdio.multiremote.conf.ts
@@ -1,0 +1,19 @@
+import type { Options } from '@wdio/types';
+import { config as baseConfig } from './wdio.conf.js';
+
+export const config: Options.Testrunner = {
+  ...baseConfig,
+  specs: ['./multiremote/*.ts'],
+  capabilities: {
+    browserA: {
+      capabilities: {
+        browserName: 'electron',
+      },
+    },
+    browserB: {
+      capabilities: {
+        browserName: 'electron',
+      },
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -68,10 +68,11 @@
     "test:unit": "vitest --coverage --watch=false",
     "test:dev": "vitest --coverage",
     "test": "pnpm test:integration && pnpm test:unit",
-    "test:integration": "cross-env DEBUG=wdio-electron-service pnpm test:integration:cjs && pnpm test:integration:esm",
+    "test:integration": "cross-env DEBUG=wdio-electron-service pnpm test:integration:cjs && pnpm test:integration:esm && pnpm test:integration:multiremote",
     "test:integration-local": "cross-env DEBUG=wdio-electron-service pnpm clean:all && pnpm i && pnpm build && pnpm test:integration",
     "test:integration:cjs": "cd example-cjs && pnpm run ci",
     "test:integration:esm": "cd example && pnpm run ci",
+    "test:integration:multiremote": "cd example && pnpm run test:multiremote",
     "update:all": "pnpm --filter=\\!fixture-\\* up -iL",
     "watch": "pnpm run build:esm --watch"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+export const APP_NOT_FOUND_ERROR =
+  'Could not find Electron app at %s build with %s!\n' +
+  'If the application is not compiled, please do so before running your tests, via `%s`.\n' +
+  'Otherwise if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities.';
+export const CUSTOM_CAPABILITY_NAME = 'wdio:electronServiceOptions';

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -11,12 +11,8 @@ import log from './log.js';
 import { getBinaryPath } from './utils.js';
 import { getChromeOptions, getChromedriverOptions, getElectronCapabilities } from './capabilities.js';
 import { getChromiumVersion } from './versions.js';
+import { APP_NOT_FOUND_ERROR, CUSTOM_CAPABILITY_NAME } from './constants.js';
 import type { ElectronServiceOptions } from './types.js';
-
-const APP_NOT_FOUND_ERROR =
-  'Could not find Electron app at %s build with %s!\n' +
-  'If the application is not compiled, please do so before running your tests, via `%s`.\n' +
-  'Otherwise if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities.';
 
 export default class ElectronLaunchService implements Services.ServiceInstance {
   #globalOptions: ElectronServiceOptions;
@@ -57,7 +53,7 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
         const chromiumVersion = await getChromiumVersion(electronVersion);
         log.debug(`found Electron v${electronVersion} with Chromedriver v${chromiumVersion}`);
 
-        let { appBinaryPath, appArgs } = Object.assign({}, this.#globalOptions, cap['wdio:electronServiceOptions']);
+        let { appBinaryPath, appArgs } = Object.assign({}, this.#globalOptions, cap[CUSTOM_CAPABILITY_NAME]);
         if (!appBinaryPath) {
           appBinaryPath = await detectBinaryPath(pkg);
         }
@@ -89,6 +85,12 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
           log.error(invalidBrowserVersionOptsError);
           throw invalidBrowserVersionOptsError;
         }
+
+        /**
+         * attach custom capability to be able to identify Electron instances
+         * in the worker process
+         */
+        cap[CUSTOM_CAPABILITY_NAME] = cap[CUSTOM_CAPABILITY_NAME] || {};
 
         log.debug('setting capability', cap);
       }),

--- a/src/service.ts
+++ b/src/service.ts
@@ -71,13 +71,9 @@ export default class ElectronWorkerService implements Services.ServiceInstance {
         const caps =
           (mrInstance.requestedCapabilities as Capabilities.W3CCapabilities).alwaysMatch ||
           (mrInstance.requestedCapabilities as WebdriverIO.Capabilities);
-        console.log('AH', caps);
-
         if (!caps[CUSTOM_CAPABILITY_NAME]) {
           continue;
         }
-        console.log('ATTACH TO in', instance);
-
         log.debug('Adding Electron API to browser object instance named: ', instance);
         mrInstance.electron = this.#getElectronAPI(mrInstance);
       }

--- a/src/service.ts
+++ b/src/service.ts
@@ -52,6 +52,7 @@ export default class ElectronWorkerService implements Services.ServiceInstance {
      * add electron API to browser object
      */
     const electron = Object.create({}, api)
+    this.#browser.electron = electron;
     if (this.#browser.isMultiremote) {
       for (const instance of mrBrowser.instances) {
         const mrInstance = mrBrowser.getInstance(instance)
@@ -62,8 +63,6 @@ export default class ElectronWorkerService implements Services.ServiceInstance {
         log.debug('Adding Electron API to browser object instance named: ', instance);
         mrInstance.electron = electron;
       }
-    } else {
-      this.#browser.electron = electron;
     }
   }
 }

--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -116,6 +116,7 @@ describe('onPrepare', () => {
         binary: 'workspace/my-test-app/dist/my-test-app',
         windowTypes: ['app', 'webview'],
       },
+      'wdio:electronServiceOptions': {},
     });
   });
 
@@ -142,6 +143,7 @@ describe('onPrepare', () => {
         binary: 'workspace/my-test-app/dist/my-test-app',
         windowTypes: ['app', 'webview'],
       },
+      'wdio:electronServiceOptions': {},
     });
   });
 
@@ -168,6 +170,7 @@ describe('onPrepare', () => {
         binary: 'workspace/my-test-app/dist/my-test-app',
         windowTypes: ['app', 'webview'],
       },
+      'wdio:electronServiceOptions': {},
     });
   });
 
@@ -194,6 +197,7 @@ describe('onPrepare', () => {
         binary: 'workspace/my-test-app/dist/my-test-app',
         windowTypes: ['app', 'webview'],
       },
+      'wdio:electronServiceOptions': {},
     });
   });
 
@@ -220,6 +224,7 @@ describe('onPrepare', () => {
         binary: 'workspace/my-test-app/dist/my-test-app',
         windowTypes: ['app', 'webview'],
       },
+      'wdio:electronServiceOptions': {},
     });
   });
 
@@ -258,6 +263,7 @@ describe('onPrepare', () => {
         binary: 'workspace/my-test-app/dist/my-test-app',
         windowTypes: ['app', 'webview'],
       },
+      'wdio:electronServiceOptions': {},
     });
   });
 
@@ -289,6 +295,7 @@ describe('onPrepare', () => {
       'wdio:chromedriverOptions': {
         binary: '/path/to/chromedriver',
       },
+      'wdio:electronServiceOptions': {},
     });
   });
 
@@ -313,6 +320,7 @@ describe('onPrepare', () => {
           binary: 'workspace/my-test-app/dist/my-test-app',
           windowTypes: ['app', 'webview'],
         },
+        'wdio:electronServiceOptions': {},
       },
     });
   });
@@ -361,6 +369,7 @@ describe('onPrepare', () => {
             binary: 'workspace/my-test-app/dist/my-test-app',
             windowTypes: ['app', 'webview'],
           },
+          'wdio:electronServiceOptions': {},
         },
       },
       chrome: {
@@ -379,6 +388,7 @@ describe('onPrepare', () => {
               binary: 'workspace/my-test-app/dist/my-test-app',
               windowTypes: ['app', 'webview'],
             },
+            'wdio:electronServiceOptions': {},
           },
         },
       },
@@ -434,6 +444,7 @@ describe('onPrepare', () => {
               binary: 'workspace/my-test-app/dist/my-test-app',
               windowTypes: ['app', 'webview'],
             },
+            'wdio:electronServiceOptions': {},
           },
         },
       },
@@ -454,6 +465,7 @@ describe('onPrepare', () => {
                 binary: 'workspace/my-test-app/dist/my-test-app',
                 windowTypes: ['app', 'webview'],
               },
+              'wdio:electronServiceOptions': {},
             },
           },
         },


### PR DESCRIPTION
This patch will allow to run Electron tests in combination with another browser instance to test e.g. chat applications.