### PR TITLE
fix: move execute error into callback

### DIFF
--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -1,4 +1,3 @@
-import { CONTEXT_BRIDGE_NOT_AVAILABLE } from '../constants.js';
 import type ElectronWorkerService from '../service.js';
 
 export async function execute<ReturnValue, InnerArguments extends unknown[]>(
@@ -23,13 +22,17 @@ export async function execute<ReturnValue, InnerArguments extends unknown[]>(
   }
 
   return browser.execute(
-    function executeWithinElectron(errMessage: string, script: string, ...args) {
+    function executeWithinElectron(script: string, ...args) {
       if (window.wdioElectron === undefined) {
+        const errMessage =
+          'Electron context bridge not available! ' +
+          'Did you import the service hook scripts into your application via e.g. ' +
+          "`import('wdio-electron-service/main')` and `import('wdio-electron-service/preload')`?\n\n" +
+          'Find more information at https://webdriver.io/docs/desktop-testing/electron#api-configuration';
         throw new Error(errMessage);
       }
       return window.wdioElectron.execute(script, args);
     },
-    CONTEXT_BRIDGE_NOT_AVAILABLE,
     `${script}`,
     ...args,
   ) as ReturnValue;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,11 +9,6 @@ export const BUILD_TOOL_DETECTION_ERROR =
 export const APP_NAME_DETECTION_ERROR =
   'No application name was detected, please set name / productName in your package.json or build tool configuration.';
 export const CUSTOM_CAPABILITY_NAME = 'wdio:electronServiceOptions';
-export const CONTEXT_BRIDGE_NOT_AVAILABLE =
-  'Electron context bridge not available! ' +
-  'Did you import the service hook scripts into your application via e.g. ' +
-  "`import('wdio-electron-service/main')` and `import('wdio-electron-service/preload')`?\n\n" +
-  'Find more information at https://webdriver.io/docs/desktop-testing/electron#api-configuration';
 
 export enum Channel {
   Custom = 'wdio-electron',

--- a/test/commands/execute.spec.ts
+++ b/test/commands/execute.spec.ts
@@ -2,7 +2,6 @@ import { vi, describe, beforeEach, it, expect } from 'vitest';
 
 import { execute } from '../../src/commands/execute';
 import ElectronWorkerService from '../../src';
-import { CONTEXT_BRIDGE_NOT_AVAILABLE } from '../../src/constants';
 
 describe('execute', () => {
   let workerService;
@@ -40,10 +39,6 @@ describe('execute', () => {
 
   it('should execute a function', async () => {
     await execute.call(workerService, () => 1 + 2 + 3);
-    expect(globalThis.browser.execute).toHaveBeenCalledWith(
-      expect.any(Function),
-      CONTEXT_BRIDGE_NOT_AVAILABLE,
-      '() => 1 + 2 + 3',
-    );
+    expect(globalThis.browser.execute).toHaveBeenCalledWith(expect.any(Function), '() => 1 + 2 + 3');
   });
 });


### PR DESCRIPTION
Refactor to mitigate confusion around logging of `execute` calls, e.g. in #337 