### PR TITLE
test: units cleanup and coverage improvements

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,11 +11,5 @@ export const APP_NAME_DETECTION_ERROR =
 export const CUSTOM_CAPABILITY_NAME = 'wdio:electronServiceOptions';
 
 export enum Channel {
-  Custom = 'wdio-electron',
-  App = 'wdio-electron.app',
-  BrowserWindow = 'wdio-electron.browserWindow',
-  Dialog = 'wdio-electron.dialog',
-  MainProcess = 'wdio-electron.mainProcess',
-  Mock = 'wdio-electron.mock',
   Execute = 'wdio-electron.execute',
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -6,7 +6,7 @@ import { type ElectronServiceMock, mock } from './commands/mock.js';
 import { removeMocks } from './commands/removeMocks.js';
 import { mockAll } from './commands/mockAll.js';
 import { CUSTOM_CAPABILITY_NAME } from './constants.js';
-import type { BrowserExtension } from './index.js';
+import type { AbstractFn, BrowserExtension } from './index.js';
 
 export default class ElectronWorkerService implements Services.ServiceInstance {
   #browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser;
@@ -25,8 +25,7 @@ export default class ElectronWorkerService implements Services.ServiceInstance {
     const browser = (browserInstance || this.browser) as WebdriverIO.Browser;
     const api = {
       _mocks: {} as Record<string, ElectronServiceMock>,
-      execute: (script: string | ((...innerArgs: unknown[]) => unknown), ...args: unknown[]) =>
-        execute.apply(this, [browser, script, ...args]),
+      execute: (script: string | AbstractFn, ...args: unknown[]) => execute.apply(this, [browser, script, ...args]),
       mock: mock.bind(this),
       mockAll: mockAll.bind(this),
       removeMocks: removeMocks.bind(this),

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,13 +5,13 @@ import type * as Electron from 'electron';
  */
 process.env.WDIO_ELECTRON = 'true';
 
-type MockFn = (...args: unknown[]) => unknown;
+export type AbstractFn = (...args: unknown[]) => unknown;
 type WrappedMockFn = {
-  mockReturnValue: (returnValue: unknown) => Promise<MockFn>;
-  mockImplementation: (implementationFn: () => unknown) => Promise<MockFn>;
-  update: () => Promise<MockFn>;
+  mockReturnValue: (returnValue: unknown) => Promise<AbstractFn>;
+  mockImplementation: (implementationFn: () => unknown) => Promise<AbstractFn>;
+  update: () => Promise<AbstractFn>;
   unMock: () => Promise<void>;
-} & MockFn;
+} & AbstractFn;
 
 export interface ElectronServiceAPI {
   /**

--- a/test/commands/execute.spec.ts
+++ b/test/commands/execute.spec.ts
@@ -5,8 +5,16 @@ import { execute } from '../../src/commands/execute';
 describe('execute', () => {
   beforeEach(async () => {
     globalThis.browser = {
-      execute: vi.fn(),
+      execute: vi
+        .fn()
+        .mockImplementation(
+          (fn: (script: string, ...args: unknown[]) => unknown, script: string, ...args: unknown[]) =>
+            typeof fn === 'string' ? new Function(`return (${fn}).apply(this, arguments)`)() : fn(script, ...args),
+        ),
     } as unknown as WebdriverIO.Browser;
+    globalThis.wdioElectron = {
+      execute: vi.fn(),
+    };
   });
 
   it('should throw an error when called with a script argument of the wrong type', async () => {
@@ -29,13 +37,27 @@ describe('execute', () => {
     );
   });
 
-  it('should execute a stringified function', async () => {
-    await execute(globalThis.browser, 'return 1 + 2 + 3');
-    expect(globalThis.browser.execute).toHaveBeenCalledWith('return 1 + 2 + 3');
+  it('should throw an error when the context bridge is not available', async () => {
+    delete globalThis.wdioElectron;
+    await expect(() => execute(globalThis.browser, () => 1 + 2 + 3)).rejects.toThrowError(
+      new Error(
+        'Electron context bridge not available! ' +
+          'Did you import the service hook scripts into your application via e.g. ' +
+          "`import('wdio-electron-service/main')` and `import('wdio-electron-service/preload')`?\n\n" +
+          'Find more information at https://webdriver.io/docs/desktop-testing/electron#api-configuration',
+      ),
+    );
   });
 
   it('should execute a function', async () => {
-    await execute(globalThis.browser, () => 1 + 2 + 3);
-    expect(globalThis.browser.execute).toHaveBeenCalledWith(expect.any(Function), '() => 1 + 2 + 3');
+    await execute(globalThis.browser, (a, b, c) => a + b + c, 1, 2, 3);
+    expect(globalThis.browser.execute).toHaveBeenCalledWith(expect.any(Function), '(a, b, c) => a + b + c', 1, 2, 3);
+    expect(globalThis.wdioElectron.execute).toHaveBeenCalledWith('(a, b, c) => a + b + c', [1, 2, 3]);
+  });
+
+  it('should execute a stringified function', async () => {
+    await execute(globalThis.browser, '() => 1 + 2 + 3');
+    expect(globalThis.browser.execute).toHaveBeenCalledWith('() => 1 + 2 + 3');
+    expect(globalThis.wdioElectron.execute).not.toHaveBeenCalled();
   });
 });

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,31 +1,44 @@
-import { vi, describe, beforeEach, afterEach, it, expect } from 'vitest';
+import { vi, beforeEach, afterEach, it, expect } from 'vitest';
 import { IpcMainInvokeEvent } from 'electron';
 
-const ipcMainHandleMock = vi.fn();
+const ipcMain = {
+  handle: vi.fn(),
+};
+const app = {
+  getName: () => 'test',
+};
+const electronMock = {
+  ipcMain,
+  app,
+  default: { ipcMain, app },
+};
 
-vi.mock('electron', () => ({
-  ipcMain: { handle: ipcMainHandleMock },
-  default: {
-    ipcMain: { handle: ipcMainHandleMock },
-  },
-}));
+vi.mock('electron', () => electronMock);
 
-describe('main', () => {
-  let listeners: { [Key: string]: (event: IpcMainInvokeEvent, funcName: string, ...args: unknown[]) => unknown } = {};
+let listeners: { [Key: string]: (event: IpcMainInvokeEvent, funcName: string, ...args: unknown[]) => unknown } = {};
 
-  beforeEach(async () => {
-    ipcMainHandleMock.mockImplementation((channel: string, listener: () => void) => {
-      listeners[channel] = listener;
-    });
-    await import('../src/main');
+beforeEach(async () => {
+  ipcMain.handle.mockImplementation((channel: string, listener: () => void) => {
+    listeners[channel] = listener;
   });
+  await import('../src/main');
+});
 
-  afterEach(() => {
-    vi.resetModules();
-    listeners = {};
-  });
+afterEach(() => {
+  vi.resetModules();
+  listeners = {};
+});
 
-  it('should call ipcMain.handle with the expected parameters', () => {
-    expect(ipcMainHandleMock.mock.calls).toEqual([['wdio-electron.execute', expect.any(Function)]]);
-  });
+it('should call ipcMain.handle with the expected parameters', () => {
+  expect(ipcMain.handle.mock.calls).toEqual([['wdio-electron.execute', expect.any(Function)]]);
+});
+
+it('should execute a script', () => {
+  expect(
+    ipcMain.handle.mock.calls[0][1](
+      undefined,
+      (electron: typeof electronMock, a: number, b: number, c: number) => electron.app.getName() + a + b + c,
+      [1, 2, 3],
+    ),
+  ).toBe('test123');
 });

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -40,7 +40,6 @@ describe('before', () => {
       instance.before({}, [], instance.browser);
 
       const electronInstance = instance.browser.getInstance('electron');
-      console.log('ZOMG', electronInstance, browser);
       let serviceApi = electronInstance.electron;
       expect(serviceApi.execute).toEqual(expect.any(Function));
       expect(serviceApi.mock).toEqual(expect.any(Function));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,5 @@
 import { configDefaults, defineConfig } from 'vitest/config';
 
-const symlinkedCJSFiles = ['src/cjs/constants.ts', 'src/cjs/main.ts', 'src/cjs/preload.ts', 'src/cjs/types.ts'];
-
 export default defineConfig({
   test: {
     include: ['test/**/*.spec.ts'],
@@ -10,7 +8,7 @@ export default defineConfig({
     coverage: {
       enabled: true,
       include: ['src/**/*'],
-      exclude: [...symlinkedCJSFiles, 'src/types.ts'],
+      exclude: ['src/cjs/*.ts', 'src/index.ts', 'src/types.ts'],
       thresholds: {
         lines: 70,
         functions: 70,


### PR DESCRIPTION
* Improving unit coverage mostly related to `execute`
* Excluding all CJS files and the ESM `index.ts` from coverage
* Some cleanup