### PR TITLE
(feat): add mock object properties

### DIFF
--- a/docs/electron-apis/mocking-apis.md
+++ b/docs/electron-apis/mocking-apis.md
@@ -356,8 +356,6 @@ expect(withImplementationResult).toBe('temporary mock name');
 
 It can also be used with an asynchronous callback:
 
-@example
-
 ```js
 const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
 const withImplementationResult = await mockGetFileIcon.withImplementation(
@@ -421,4 +419,83 @@ await mockGetName.mockReturnThis();
 await browser.electron.execute((electron) => electron.app.getName().getVersion());
 
 expect(mockGetVersion).toHaveBeenCalled();
+```
+
+### `mock.calls`
+
+This is an array containing all arguments for each call. Each item of the array is the arguments of that call.
+
+```js
+const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+
+await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/another/icon', { size: 'small' }));
+
+expect(mockGetFileIcon.mock.calls).toStrictEqual([
+  ['/path/to/icon'], // first call
+  ['/path/to/another/icon', { size: 'small' }], // second call
+]);
+```
+
+### `mock.lastCall`
+
+This contains the arguments of the last call. If the mock wasn't called, it will return `undefined`.
+
+```js
+const mockSetName = await browser.electron.mock('app', 'setName');
+
+await browser.electron.execute((electron) => electron.app.setName('test'));
+expect(mockSetName.mock.lastCall).toStrictEqual(['test']);
+await browser.electron.execute((electron) => electron.app.setName('test 2'));
+expect(mockSetName.mock.lastCall).toStrictEqual(['test 2']);
+await browser.electron.execute((electron) => electron.app.setName('test 3'));
+expect(mockSetName.mock.lastCall).toStrictEqual(['test 3']);
+```
+
+### `mock.results`
+
+This is an array containing all values that were returned from the mock. Each item of the array is an object with the properties type and value. Available types are:
+
+    'return' - the mock returned without throwing.
+    'throw' - the mock threw a value.
+
+The value property contains the returned value or the thrown error. If the mock returned a promise, the value will be the resolved value, not the Promise itself, unless it was never resolved.
+
+```js
+const mockGetName = await browser.electron.mock('app', 'getName');
+
+await mockGetName.mockImplementationOnce(() => 'result');
+await mockGetName.mockImplementation(() => {
+  throw new Error('thrown error');
+});
+
+await expect(browser.electron.execute((electron) => electron.app.getName())).resolves.toBe('result');
+await expect(browser.electron.execute((electron) => electron.app.getName())).rejects.toThrow('thrown error');
+
+expect(mockGetName.mock.results).toStrictEqual([
+  {
+    type: 'return',
+    value: 'result',
+  },
+  {
+    type: 'throw',
+    value: new Error('thrown error'),
+  },
+]);
+```
+
+### `mock.invocationCallOrder`
+
+The order of mock invocation. This returns an array of numbers that are shared between all defined mocks. Will return an empty array if the mock was never invoked.
+
+```js
+const mockGetName = await browser.electron.mock('app', 'getName');
+const mockGetVersion = await browser.electron.mock('app', 'getVersion');
+
+await browser.electron.execute((electron) => electron.app.getName());
+await browser.electron.execute((electron) => electron.app.getVersion());
+await browser.electron.execute((electron) => electron.app.getName());
+
+expect(mockGetName.mock.invocationCallOrder).toStrictEqual([1, 3]);
+expect(mockGetVersion.mock.invocationCallOrder).toStrictEqual([2]);
 ```

--- a/example-cjs/e2e/api.spec.ts
+++ b/example-cjs/e2e/api.spec.ts
@@ -4,8 +4,6 @@ import type { Mock } from '@vitest/spy';
 
 const { name: pkgAppName, version: pkgAppVersion } = globalThis.packageJson;
 
-// TODO: more use of `await expect(browser.electron.execute((electron) => electron.x.y())).resolves.toBe(z)`
-
 describe('mock', () => {
   it('should mock an electron API function', async () => {
     const mockShowOpenDialog = await browser.electron.mock('dialog', 'showOpenDialog');
@@ -150,11 +148,13 @@ describe('resetAllMocks', () => {
     await browser.electron.resetAllMocks();
 
     expect(mockGetName.mock.calls).toStrictEqual([]);
+    expect(mockGetName.mock.instances).toStrictEqual([]);
     expect(mockGetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockGetName.mock.lastCall).toBeUndefined();
     expect(mockGetName.mock.results).toStrictEqual([]);
 
     expect(mockReadText.mock.calls).toStrictEqual([]);
+    expect(mockReadText.mock.instances).toStrictEqual([]);
     expect(mockReadText.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockReadText.mock.lastCall).toBeUndefined();
     expect(mockReadText.mock.results).toStrictEqual([]);
@@ -262,7 +262,7 @@ describe('execute', () => {
   });
 
   it('should execute a string-based function in the electron main process', async () => {
-    expect(await browser.electron.execute('return 1 + 2 + 3')).toEqual(6);
+    await expect(browser.electron.execute('return 1 + 2 + 3')).resolves.toEqual(6);
   });
 });
 
@@ -586,9 +586,12 @@ describe('mock object functionality', () => {
       );
 
       expect(withImplementationResult).toBe('temporary mock name');
-      expect(await browser.electron.execute((electron) => electron.app.getName())).toBe('first mock name');
-      expect(await browser.electron.execute((electron) => electron.app.getName())).toBe('second mock name');
-      expect(await browser.electron.execute((electron) => electron.app.getName())).toBe('default mock name');
+      const firstName = await browser.electron.execute((electron) => electron.app.getName());
+      expect(firstName).toBe('first mock name');
+      const secondName = await browser.electron.execute((electron) => electron.app.getName());
+      expect(secondName).toBe('second mock name');
+      const thirdName = await browser.electron.execute((electron) => electron.app.getName());
+      expect(thirdName).toBe('default mock name');
     });
 
     it('should handle promises', async () => {
@@ -602,15 +605,12 @@ describe('mock object functionality', () => {
       );
 
       expect(withImplementationResult).toBe('temporary mock icon');
-      expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
-        'first mock icon',
-      );
-      expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
-        'second mock icon',
-      );
-      expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
-        'default mock icon',
-      );
+      const firstIcon = await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      expect(firstIcon).toBe('first mock icon');
+      const secondIcon = await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      expect(secondIcon).toBe('second mock icon');
+      const thirdIcon = await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      expect(thirdIcon).toBe('default mock icon');
     });
   });
 

--- a/example-cjs/e2e/api.spec.ts
+++ b/example-cjs/e2e/api.spec.ts
@@ -4,6 +4,8 @@ import type { Mock } from '@vitest/spy';
 
 const { name: pkgAppName, version: pkgAppVersion } = globalThis.packageJson;
 
+// TODO: more use of `await expect(browser.electron.execute((electron) => electron.x.y())).resolves.toBe(z)`
+
 describe('mock', () => {
   it('should mock an electron API function', async () => {
     const mockShowOpenDialog = await browser.electron.mock('dialog', 'showOpenDialog');
@@ -76,13 +78,11 @@ describe('clearAllMocks', () => {
     await browser.electron.clearAllMocks();
 
     expect(mockSetName.mock.calls).toStrictEqual([]);
-    expect(mockSetName.mock.instances).toStrictEqual([]);
     expect(mockSetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockSetName.mock.lastCall).toBeUndefined();
     expect(mockSetName.mock.results).toStrictEqual([]);
 
     expect(mockWriteText.mock.calls).toStrictEqual([]);
-    expect(mockWriteText.mock.instances).toStrictEqual([]);
     expect(mockWriteText.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockWriteText.mock.lastCall).toBeUndefined();
     expect(mockWriteText.mock.results).toStrictEqual([]);
@@ -98,13 +98,11 @@ describe('clearAllMocks', () => {
     await browser.electron.clearAllMocks('app');
 
     expect(mockSetName.mock.calls).toStrictEqual([]);
-    expect(mockSetName.mock.instances).toStrictEqual([]);
     expect(mockSetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockSetName.mock.lastCall).toBeUndefined();
     expect(mockSetName.mock.results).toStrictEqual([]);
 
     expect(mockWriteText.mock.calls).toStrictEqual([['text to be written']]);
-    expect(mockWriteText.mock.instances).toStrictEqual([expect.any(Function)]);
     expect(mockWriteText.mock.invocationCallOrder).toStrictEqual([expect.any(Number)]);
     expect(mockWriteText.mock.lastCall).toStrictEqual(['text to be written']);
     expect(mockWriteText.mock.results).toStrictEqual([{ type: 'return', value: undefined }]);
@@ -152,13 +150,11 @@ describe('resetAllMocks', () => {
     await browser.electron.resetAllMocks();
 
     expect(mockGetName.mock.calls).toStrictEqual([]);
-    expect(mockGetName.mock.instances).toStrictEqual([]);
     expect(mockGetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockGetName.mock.lastCall).toBeUndefined();
     expect(mockGetName.mock.results).toStrictEqual([]);
 
     expect(mockReadText.mock.calls).toStrictEqual([]);
-    expect(mockReadText.mock.instances).toStrictEqual([]);
     expect(mockReadText.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockReadText.mock.lastCall).toBeUndefined();
     expect(mockReadText.mock.results).toStrictEqual([]);
@@ -174,13 +170,11 @@ describe('resetAllMocks', () => {
     await browser.electron.resetAllMocks('app');
 
     expect(mockSetName.mock.calls).toStrictEqual([]);
-    expect(mockSetName.mock.instances).toStrictEqual([]);
     expect(mockSetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockSetName.mock.lastCall).toBeUndefined();
     expect(mockSetName.mock.results).toStrictEqual([]);
 
     expect(mockWriteText.mock.calls).toStrictEqual([['text to be written']]);
-    expect(mockWriteText.mock.instances).toStrictEqual([expect.any(Function)]);
     expect(mockWriteText.mock.invocationCallOrder).toStrictEqual([expect.any(Number)]);
     expect(mockWriteText.mock.lastCall).toStrictEqual(['text to be written']);
     expect(mockWriteText.mock.results).toStrictEqual([{ type: 'return', value: undefined }]);
@@ -347,18 +341,88 @@ describe('mock object functionality', () => {
     });
   });
 
-  describe('mockRestore', () => {
-    it('should restore an existing mock', async () => {
-      const mockGetName = await browser.electron.mock('app', 'getName');
-      await mockGetName.mockReturnValue('mocked name');
+  describe('mockResolvedValue', () => {
+    it('should resolve with the specified value from an existing mock', async () => {
+      const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+      await mockGetFileIcon.mockResolvedValue('This is a mock');
 
-      let name = await browser.electron.execute((electron) => electron.app.getName());
-      expect(name).toBe('mocked name');
+      const fileIcon = await browser.electron.execute(
+        async (electron) => await electron.app.getFileIcon('/path/to/icon'),
+      );
 
-      await mockGetName.mockRestore();
+      expect(fileIcon).toBe('This is a mock');
+    });
+  });
 
-      name = await browser.electron.execute((electron) => electron.app.getName());
-      expect(name).toBe(pkgAppName);
+  describe('mockResolvedValueOnce', () => {
+    it('should resolve with the specified value from an existing mock once', async () => {
+      const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+
+      await mockGetFileIcon.mockResolvedValue('default mocked icon');
+      await mockGetFileIcon.mockResolvedValueOnce('first mocked icon');
+      await mockGetFileIcon.mockResolvedValueOnce('second mocked icon');
+      await mockGetFileIcon.mockResolvedValueOnce('third mocked icon');
+
+      let fileIcon = await browser.electron.execute(
+        async (electron) => await electron.app.getFileIcon('/path/to/icon'),
+      );
+      expect(fileIcon).toBe('first mocked icon');
+      fileIcon = await browser.electron.execute(async (electron) => await electron.app.getFileIcon('/path/to/icon'));
+      expect(fileIcon).toBe('second mocked icon');
+      fileIcon = await browser.electron.execute(async (electron) => await electron.app.getFileIcon('/path/to/icon'));
+      expect(fileIcon).toBe('third mocked icon');
+      fileIcon = await browser.electron.execute(async (electron) => await electron.app.getFileIcon('/path/to/icon'));
+      expect(fileIcon).toBe('default mocked icon');
+      fileIcon = await browser.electron.execute(async (electron) => await electron.app.getFileIcon('/path/to/icon'));
+      expect(fileIcon).toBe('default mocked icon');
+    });
+  });
+
+  describe('mockRejectedValue', () => {
+    it('should reject with the specified value from an existing mock', async () => {
+      const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+      await mockGetFileIcon.mockRejectedValue('This is a mock error');
+
+      const fileIconError = await browser.electron.execute(async (electron) => {
+        try {
+          await electron.app.getFileIcon('/path/to/icon');
+        } catch (e) {
+          return e;
+        }
+      });
+
+      expect(fileIconError).toBe('This is a mock error');
+    });
+  });
+
+  describe('mockRejectedValueOnce', () => {
+    it('should reject with the specified value from an existing mock once', async () => {
+      const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+
+      await mockGetFileIcon.mockRejectedValue('default mocked icon error');
+      await mockGetFileIcon.mockRejectedValueOnce('first mocked icon error');
+      await mockGetFileIcon.mockRejectedValueOnce('second mocked icon error');
+      await mockGetFileIcon.mockRejectedValueOnce('third mocked icon error');
+
+      const getFileIcon = async () =>
+        await browser.electron.execute(async (electron) => {
+          try {
+            await electron.app.getFileIcon('/path/to/icon');
+          } catch (e) {
+            return e;
+          }
+        });
+
+      let fileIcon = await getFileIcon();
+      expect(fileIcon).toBe('first mocked icon error');
+      fileIcon = await getFileIcon();
+      expect(fileIcon).toBe('second mocked icon error');
+      fileIcon = await getFileIcon();
+      expect(fileIcon).toBe('third mocked icon error');
+      fileIcon = await getFileIcon();
+      expect(fileIcon).toBe('default mocked icon error');
+      fileIcon = await getFileIcon();
+      expect(fileIcon).toBe('default mocked icon error');
     });
   });
 
@@ -382,7 +446,6 @@ describe('mock object functionality', () => {
       await mockShowOpenDialog.mockClear();
 
       expect(mockShowOpenDialog.mock.calls).toStrictEqual([]);
-      expect(mockShowOpenDialog.mock.instances).toStrictEqual([]);
       expect(mockShowOpenDialog.mock.invocationCallOrder).toStrictEqual([]);
       expect(mockShowOpenDialog.mock.lastCall).toBeUndefined();
       expect(mockShowOpenDialog.mock.results).toStrictEqual([]);
@@ -443,10 +506,210 @@ describe('mock object functionality', () => {
       await mockShowOpenDialog.mockReset();
 
       expect(mockShowOpenDialog.mock.calls).toStrictEqual([]);
-      expect(mockShowOpenDialog.mock.instances).toStrictEqual([]);
       expect(mockShowOpenDialog.mock.invocationCallOrder).toStrictEqual([]);
       expect(mockShowOpenDialog.mock.lastCall).toBeUndefined();
       expect(mockShowOpenDialog.mock.results).toStrictEqual([]);
+    });
+  });
+
+  describe('mockRestore', () => {
+    it('should restore an existing mock', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+      await mockGetName.mockReturnValue('mocked name');
+
+      let name = await browser.electron.execute((electron) => electron.app.getName());
+      expect(name).toBe('mocked name');
+
+      await mockGetName.mockRestore();
+
+      name = await browser.electron.execute((electron) => electron.app.getName());
+      expect(name).toBe(pkgAppName);
+    });
+  });
+
+  describe('getMockName', () => {
+    it('should retrieve the mock name', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      expect(mockGetName.getMockName()).toBe('electron.app.getName');
+    });
+  });
+
+  describe('mockName', () => {
+    it('should set the mock name', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+      mockGetName.mockName('my first mock');
+
+      expect(mockGetName.getMockName()).toBe('my first mock');
+    });
+  });
+
+  describe('getMockImplementation', () => {
+    it('should retrieve the mock implementation', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+      await mockGetName.mockImplementation(() => 'mocked name');
+      const mockImpl = mockGetName.getMockImplementation() as () => string;
+
+      expect(mockImpl()).toBe('mocked name');
+    });
+
+    it('should retrieve an empty mock implementation', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+      const mockImpl = mockGetName.getMockImplementation() as () => undefined;
+
+      expect(mockImpl()).toBeUndefined();
+    });
+  });
+
+  describe('mockReturnThis', () => {
+    it('should allow chaining', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+      const mockGetVersion = await browser.electron.mock('app', 'getVersion');
+      await mockGetName.mockReturnThis();
+      await browser.electron.execute((electron) =>
+        (electron.app.getName() as unknown as { getVersion: () => string }).getVersion(),
+      );
+
+      expect(mockGetVersion).toHaveBeenCalled();
+    });
+  });
+
+  describe('withImplementation', () => {
+    it('should temporarily override mock implementation', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+      await mockGetName.mockImplementation(() => 'default mock name');
+      await mockGetName.mockImplementationOnce(() => 'first mock name');
+      await mockGetName.mockImplementationOnce(() => 'second mock name');
+      const withImplementationResult = await mockGetName.withImplementation(
+        () => 'temporary mock name',
+        (electron) => electron.app.getName(),
+      );
+
+      expect(withImplementationResult).toBe('temporary mock name');
+      expect(await browser.electron.execute((electron) => electron.app.getName())).toBe('first mock name');
+      expect(await browser.electron.execute((electron) => electron.app.getName())).toBe('second mock name');
+      expect(await browser.electron.execute((electron) => electron.app.getName())).toBe('default mock name');
+    });
+
+    it('should handle promises', async () => {
+      const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+      await mockGetFileIcon.mockResolvedValue('default mock icon');
+      await mockGetFileIcon.mockResolvedValueOnce('first mock icon');
+      await mockGetFileIcon.mockResolvedValueOnce('second mock icon');
+      const withImplementationResult = await mockGetFileIcon.withImplementation(
+        () => Promise.resolve('temporary mock icon'),
+        async (electron) => await electron.app.getFileIcon('/path/to/icon'),
+      );
+
+      expect(withImplementationResult).toBe('temporary mock icon');
+      expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
+        'first mock icon',
+      );
+      expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
+        'second mock icon',
+      );
+      expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
+        'default mock icon',
+      );
+    });
+  });
+
+  describe('mock.calls', () => {
+    it('should return the calls of the mock execution', async () => {
+      const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+
+      await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      await browser.electron.execute((electron) =>
+        electron.app.getFileIcon('/path/to/another/icon', { size: 'small' }),
+      );
+
+      expect(mockGetFileIcon.mock.calls).toStrictEqual([
+        ['/path/to/icon'], // first call
+        ['/path/to/another/icon', { size: 'small' }], // second call
+      ]);
+    });
+
+    it('should return an empty array when the mock was never invoked', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      expect(mockGetName.mock.calls).toStrictEqual([]);
+    });
+  });
+
+  describe('mock.lastCall', () => {
+    it('should return the last call of the mock execution', async () => {
+      const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+
+      await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      expect(mockGetFileIcon.mock.lastCall).toStrictEqual(['/path/to/icon']);
+      await browser.electron.execute((electron) =>
+        electron.app.getFileIcon('/path/to/another/icon', { size: 'small' }),
+      );
+      expect(mockGetFileIcon.mock.lastCall).toStrictEqual(['/path/to/another/icon', { size: 'small' }]);
+      await browser.electron.execute((electron) =>
+        electron.app.getFileIcon('/path/to/a/massive/icon', { size: 'large' }),
+      );
+      expect(mockGetFileIcon.mock.lastCall).toStrictEqual(['/path/to/a/massive/icon', { size: 'large' }]);
+    });
+
+    it('should return undefined when the mock was never invoked', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      expect(mockGetName.mock.lastCall).toBeUndefined();
+    });
+  });
+
+  describe('mock.results', () => {
+    it('should return the results of the mock execution', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      // TODO: why does `mockReturnValueOnce` not work for returning 'result' here?
+      await mockGetName.mockImplementationOnce(() => 'result');
+      await mockGetName.mockImplementation(() => {
+        throw new Error('thrown error');
+      });
+
+      await expect(browser.electron.execute((electron) => electron.app.getName())).resolves.toBe('result');
+      await expect(browser.electron.execute((electron) => electron.app.getName())).rejects.toThrow('thrown error');
+
+      expect(mockGetName.mock.results).toStrictEqual([
+        {
+          type: 'return',
+          value: 'result',
+        },
+        {
+          type: 'throw',
+          value: new Error('thrown error'),
+        },
+      ]);
+    });
+
+    it('should return an empty array when the mock was never invoked', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      expect(mockGetName.mock.results).toStrictEqual([]);
+    });
+  });
+
+  describe('mock.invocationCallOrder', () => {
+    it('should return the order of execution', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+      const mockGetVersion = await browser.electron.mock('app', 'getVersion');
+
+      await browser.electron.execute((electron) => electron.app.getName());
+      await browser.electron.execute((electron) => electron.app.getVersion());
+      await browser.electron.execute((electron) => electron.app.getName());
+
+      const firstInvocationIndex = mockGetName.mock.invocationCallOrder[0];
+
+      expect(mockGetName.mock.invocationCallOrder).toStrictEqual([firstInvocationIndex, firstInvocationIndex + 2]);
+      expect(mockGetVersion.mock.invocationCallOrder).toStrictEqual([firstInvocationIndex + 1]);
+    });
+
+    it('should return an empty array when the mock was never invoked', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      expect(mockGetName.mock.invocationCallOrder).toStrictEqual([]);
     });
   });
 });

--- a/example-cjs/pnpm-lock.yaml
+++ b/example-cjs/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   wdio-electron-service:
     specifier: file:../
-    version: file:..(electron@29.0.1)(webdriverio@8.32.3)
+    version: file:..(electron@29.1.0)(webdriverio@8.32.3)
 
 devDependencies:
   '@electron-forge/cli':
@@ -15,7 +15,7 @@ devDependencies:
     version: 7.3.0
   '@types/node':
     specifier: ^20.11.0
-    version: 20.11.20
+    version: 20.11.21
   '@wdio/cli':
     specifier: ^8.27.2
     version: 8.32.3(typescript@5.3.3)
@@ -30,7 +30,7 @@ devDependencies:
     version: 8.32.3
   electron:
     specifier: ^29.0.1
-    version: 29.0.1
+    version: 29.1.0
   global-jsdom:
     specifier: ^24.0.0
     version: 24.0.0(jsdom@24.0.0)
@@ -42,7 +42,7 @@ devDependencies:
     version: 9.5.1(typescript@5.3.3)(webpack@5.90.3)
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.2(@types/node@20.11.20)(typescript@5.3.3)
+    version: 10.9.2(@types/node@20.11.21)(typescript@5.3.3)
   typescript:
     specifier: ^5.3.2
     version: 5.3.3
@@ -479,7 +479,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
@@ -682,18 +682,18 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/responselike': 1.0.3
 
   /@types/eslint-scope@3.7.7:
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
     dependencies:
-      '@types/eslint': 8.56.3
+      '@types/eslint': 8.56.4
       '@types/estree': 1.0.5
     dev: true
 
-  /@types/eslint@8.56.3:
-    resolution: {integrity: sha512-PvSf1wfv2wJpVIFUMSb+i4PvqNYkB9Rkp9ZDO3oaWzq4SKhsQk4mrMBr3ZH06I0hKrVGLBacmgl8JM4WVjb9dg==}
+  /@types/eslint@8.56.4:
+    resolution: {integrity: sha512-lG1GLUnL5vuRBGb3MgWUWLdGMH2Hps+pERuyQXCfWozuGKdnhf9Pbg4pkcrVUHjKrU7Rl+GCZ/299ObBXZFAxg==}
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
@@ -732,14 +732,14 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@types/mocha@10.0.6:
     resolution: {integrity: sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==}
     dev: true
 
-  /@types/node@20.11.20:
-    resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
+  /@types/node@20.11.21:
+    resolution: {integrity: sha512-/ySDLGscFPNasfqStUuWWPfL78jompfIoVzLJPVVAHBh6rpG68+pI2Gk+fNLeI8/f1yPYL4s46EleVIc20F1Ow==}
     dependencies:
       undici-types: 5.26.5
 
@@ -749,7 +749,7 @@ packages:
   /@types/responselike@1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -762,7 +762,7 @@ packages:
   /@types/ws@8.5.10:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -780,7 +780,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     optional: true
 
   /@vitest/snapshot@1.3.1:
@@ -802,7 +802,7 @@ packages:
     engines: {node: ^16.13 || >=18}
     hasBin: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@vitest/snapshot': 1.3.1
       '@wdio/config': 8.32.3
       '@wdio/globals': 8.32.3(typescript@5.3.3)
@@ -868,7 +868,7 @@ packages:
     resolution: {integrity: sha512-YgqYkKarx2m9OjA8WO4NqQPCfFNLmZHnuEWQ6P2LqUeYFsdXRd3wR3UTo9XrI23VSQo+kcpqInsR5vLOYDd1zg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/logger': 8.28.0
       '@wdio/repl': 8.24.12
       '@wdio/runner': 8.32.3(typescript@5.3.3)
@@ -899,7 +899,7 @@ packages:
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/mocha': 10.0.6
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/logger': 8.28.0
       '@wdio/types': 8.32.2
       '@wdio/utils': 8.32.3
@@ -915,13 +915,13 @@ packages:
     resolution: {integrity: sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@wdio/runner@8.32.3(typescript@5.3.3):
     resolution: {integrity: sha512-HlhdQ4lJ07seL7/x0UQPDnK+o5a0okyjd8ukFYqDL+g9+d3KlW/oM3NvFfX7pb9liIYNEpmoNMwKFp+5XPUE7w==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/config': 8.32.3
       '@wdio/globals': 8.32.3(typescript@5.3.3)
       '@wdio/logger': 8.28.0
@@ -945,7 +945,7 @@ packages:
     resolution: {integrity: sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@wdio/utils@8.32.3:
     resolution: {integrity: sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==}
@@ -1325,8 +1325,8 @@ packages:
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  /basic-ftp@5.0.4:
-    resolution: {integrity: sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==}
+  /basic-ftp@5.0.5:
+    resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
 
   /big-integer@1.6.52:
@@ -1392,7 +1392,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001591
-      electron-to-chromium: 1.4.682
+      electron-to-chromium: 1.4.685
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
     dev: true
@@ -1974,17 +1974,17 @@ packages:
       jake: 10.8.7
     dev: true
 
-  /electron-to-chromium@1.4.682:
-    resolution: {integrity: sha512-oCglfs8yYKs9RQjJFOHonSnhikPK3y+0SvSYc/YpYJV//6rqc0/hbwd0c7vgK4vrl6y2gJAwjkhkSGWK+z4KRA==}
+  /electron-to-chromium@1.4.685:
+    resolution: {integrity: sha512-yDYeobbTEe4TNooEzOQO6xFqg9XnAkVy2Lod1C1B2it8u47JNLYvl9nLDWBamqUakWB8Jc1hhS1uHUNYTNQdfw==}
 
-  /electron@29.0.1:
-    resolution: {integrity: sha512-hsQr9clm8NCAMv4uhHlXThHn52UAgrHgyz3ubBAxZIPuUcpKVDtg4HPmx4hbmHIbYICI5OyLN3Ztp7rS+Dn4Lw==}
+  /electron@29.1.0:
+    resolution: {integrity: sha512-giJVIm0sWVp+8V1GXrKqKTb+h7no0P3ooYqEd34AD9wMJzGnAeL+usj+R0155/0pdvvP1mgydnA7lcaFA2M9lw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -2562,7 +2562,7 @@ packages:
     resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
     engines: {node: '>= 14'}
     dependencies:
-      basic-ftp: 5.0.4
+      basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
       debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 11.2.0
@@ -3118,7 +3118,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3129,7 +3129,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -4984,7 +4984,7 @@ packages:
       webpack: 5.90.3
     dev: true
 
-  /ts-node@10.9.2(@types/node@20.11.20)(typescript@5.3.3):
+  /ts-node@10.9.2(@types/node@20.11.21)(typescript@5.3.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -5003,7 +5003,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -5195,7 +5195,7 @@ packages:
     resolution: {integrity: sha512-1/kpZvuftt59oikHs+6FvWXNfOM5tgMMMAk3LnMe7D938dVOoNGAe46fq0oL/xsxxPicbMRTRgIy1OifLiglaA==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/ws': 8.5.10
       '@wdio/config': 8.32.3
       '@wdio/logger': 8.28.0
@@ -5220,7 +5220,7 @@ packages:
       devtools:
         optional: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/config': 8.32.3
       '@wdio/logger': 8.28.0
       '@wdio/protocols': 8.32.0
@@ -5528,7 +5528,7 @@ packages:
       compress-commons: 5.0.3
       readable-stream: 3.6.2
 
-  file:..(electron@29.0.1)(webdriverio@8.32.3):
+  file:..(electron@29.1.0)(webdriverio@8.32.3):
     resolution: {directory: .., type: directory}
     id: file:..
     name: wdio-electron-service
@@ -5544,8 +5544,8 @@ packages:
       '@wdio/logger': 8.28.0
       compare-versions: 6.1.0
       debug: 4.3.4(supports-color@8.1.1)
-      electron: 29.0.1
-      electron-to-chromium: 1.4.682
+      electron: 29.1.0
+      electron-to-chromium: 1.4.685
       fast-copy: 3.0.1
       find-versions: 5.1.0
       node-fetch: 3.3.2

--- a/example-electron-builder/pnpm-lock.yaml
+++ b/example-electron-builder/pnpm-lock.yaml
@@ -13,7 +13,7 @@ devDependencies:
     version: 15.2.3(rollup@4.12.0)
   '@types/node':
     specifier: ^20.11.0
-    version: 20.11.20
+    version: 20.11.21
   '@wdio/cli':
     specifier: ^8.27.2
     version: 8.32.3(typescript@5.3.3)
@@ -28,7 +28,7 @@ devDependencies:
     version: 8.32.3
   electron:
     specifier: ^29.0.1
-    version: 29.0.1
+    version: 29.1.0
   electron-builder:
     specifier: ^24.6.4
     version: 24.12.0
@@ -46,13 +46,13 @@ devDependencies:
     version: 9.5.1(typescript@5.3.3)(webpack@5.90.3)
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.2(@types/node@20.11.20)(typescript@5.3.3)
+    version: 10.9.2(@types/node@20.11.21)(typescript@5.3.3)
   typescript:
     specifier: ^5.3.2
     version: 5.3.3
   wdio-electron-service:
     specifier: file:../
-    version: file:..(electron@29.0.1)(webdriverio@8.32.3)
+    version: file:..(electron@29.1.0)(webdriverio@8.32.3)
   webdriverio:
     specifier: ^8.27.2
     version: 8.32.3(typescript@5.3.3)
@@ -205,7 +205,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
@@ -538,7 +538,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/responselike': 1.0.3
     dev: true
 
@@ -551,12 +551,12 @@ packages:
   /@types/eslint-scope@3.7.7:
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
     dependencies:
-      '@types/eslint': 8.56.3
+      '@types/eslint': 8.56.4
       '@types/estree': 1.0.5
     dev: true
 
-  /@types/eslint@8.56.3:
-    resolution: {integrity: sha512-PvSf1wfv2wJpVIFUMSb+i4PvqNYkB9Rkp9ZDO3oaWzq4SKhsQk4mrMBr3ZH06I0hKrVGLBacmgl8JM4WVjb9dg==}
+  /@types/eslint@8.56.4:
+    resolution: {integrity: sha512-lG1GLUnL5vuRBGb3MgWUWLdGMH2Hps+pERuyQXCfWozuGKdnhf9Pbg4pkcrVUHjKrU7Rl+GCZ/299ObBXZFAxg==}
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
@@ -569,7 +569,7 @@ packages:
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@types/http-cache-semantics@4.0.4:
@@ -602,7 +602,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@types/mocha@10.0.6:
@@ -613,8 +613,8 @@ packages:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: true
 
-  /@types/node@20.11.20:
-    resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
+  /@types/node@20.11.21:
+    resolution: {integrity: sha512-/ySDLGscFPNasfqStUuWWPfL78jompfIoVzLJPVVAHBh6rpG68+pI2Gk+fNLeI8/f1yPYL4s46EleVIc20F1Ow==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -627,7 +627,7 @@ packages:
     resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       xmlbuilder: 15.1.1
     dev: true
     optional: true
@@ -639,7 +639,7 @@ packages:
   /@types/responselike@1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@types/stack-utils@2.0.3:
@@ -660,7 +660,7 @@ packages:
   /@types/ws@8.5.10:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@types/yargs-parser@21.0.3:
@@ -679,7 +679,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
     optional: true
 
@@ -702,7 +702,7 @@ packages:
     engines: {node: ^16.13 || >=18}
     hasBin: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@vitest/snapshot': 1.3.1
       '@wdio/config': 8.32.3
       '@wdio/globals': 8.32.3(typescript@5.3.3)
@@ -769,7 +769,7 @@ packages:
     resolution: {integrity: sha512-YgqYkKarx2m9OjA8WO4NqQPCfFNLmZHnuEWQ6P2LqUeYFsdXRd3wR3UTo9XrI23VSQo+kcpqInsR5vLOYDd1zg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/logger': 8.28.0
       '@wdio/repl': 8.24.12
       '@wdio/runner': 8.32.3(typescript@5.3.3)
@@ -801,7 +801,7 @@ packages:
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/mocha': 10.0.6
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/logger': 8.28.0
       '@wdio/types': 8.32.2
       '@wdio/utils': 8.32.3
@@ -818,14 +818,14 @@ packages:
     resolution: {integrity: sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@wdio/runner@8.32.3(typescript@5.3.3):
     resolution: {integrity: sha512-HlhdQ4lJ07seL7/x0UQPDnK+o5a0okyjd8ukFYqDL+g9+d3KlW/oM3NvFfX7pb9liIYNEpmoNMwKFp+5XPUE7w==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/config': 8.32.3
       '@wdio/globals': 8.32.3(typescript@5.3.3)
       '@wdio/logger': 8.28.0
@@ -849,7 +849,7 @@ packages:
     resolution: {integrity: sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@wdio/utils@8.32.3:
@@ -982,7 +982,6 @@ packages:
   /@xmldom/xmldom@0.8.10:
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
-    requiresBuild: true
     dev: true
 
   /@xtuc/ieee754@1.2.0:
@@ -1262,8 +1261,8 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: true
 
-  /basic-ftp@5.0.4:
-    resolution: {integrity: sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==}
+  /basic-ftp@5.0.5:
+    resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
     dev: true
 
@@ -1342,7 +1341,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001591
-      electron-to-chromium: 1.4.682
+      electron-to-chromium: 1.4.685
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
     dev: true
@@ -2032,18 +2031,18 @@ packages:
       - supports-color
     dev: true
 
-  /electron-to-chromium@1.4.682:
-    resolution: {integrity: sha512-oCglfs8yYKs9RQjJFOHonSnhikPK3y+0SvSYc/YpYJV//6rqc0/hbwd0c7vgK4vrl6y2gJAwjkhkSGWK+z4KRA==}
+  /electron-to-chromium@1.4.685:
+    resolution: {integrity: sha512-yDYeobbTEe4TNooEzOQO6xFqg9XnAkVy2Lod1C1B2it8u47JNLYvl9nLDWBamqUakWB8Jc1hhS1uHUNYTNQdfw==}
     dev: true
 
-  /electron@29.0.1:
-    resolution: {integrity: sha512-hsQr9clm8NCAMv4uhHlXThHn52UAgrHgyz3ubBAxZIPuUcpKVDtg4HPmx4hbmHIbYICI5OyLN3Ztp7rS+Dn4Lw==}
+  /electron@29.1.0:
+    resolution: {integrity: sha512-giJVIm0sWVp+8V1GXrKqKTb+h7no0P3ooYqEd34AD9wMJzGnAeL+usj+R0155/0pdvvP1mgydnA7lcaFA2M9lw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -2285,7 +2284,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    requiresBuild: true
     dev: true
 
   /fast-fifo@1.3.2:
@@ -2294,7 +2292,6 @@ packages:
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-    requiresBuild: true
     dev: true
 
   /fd-slicer@1.1.0:
@@ -2531,7 +2528,7 @@ packages:
     resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
     engines: {node: '>= 14'}
     dependencies:
-      basic-ftp: 5.0.4
+      basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
       debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 11.2.0
@@ -3078,7 +3075,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3089,7 +3086,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -3161,7 +3158,6 @@ packages:
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-    requiresBuild: true
     dev: true
 
   /json-stringify-safe@5.0.1:
@@ -4087,11 +4083,12 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+  /rimraf@5.0.5:
+    resolution: {integrity: sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==}
+    engines: {node: '>=14'}
     hasBin: true
     dependencies:
-      glob: 7.2.3
+      glob: 10.3.10
     dev: true
 
   /roarr@2.15.4:
@@ -4591,7 +4588,7 @@ packages:
   /tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
     dependencies:
-      tmp: 0.2.1
+      tmp: 0.2.2
     dev: true
 
   /tmp@0.0.33:
@@ -4601,11 +4598,11 @@ packages:
       os-tmpdir: 1.0.2
     dev: true
 
-  /tmp@0.2.1:
-    resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
-    engines: {node: '>=8.17.0'}
+  /tmp@0.2.2:
+    resolution: {integrity: sha512-ETcvHhaIc9J2MDEAH6N67j9bvBvu/3Gb764qaGhwtFvjtvhegqoqSpofgeyq1Sc24mW5pdyUDs9HP5j3ehkxRw==}
+    engines: {node: '>=14'}
     dependencies:
-      rimraf: 3.0.2
+      rimraf: 5.0.5
     dev: true
 
   /to-regex-range@5.0.1:
@@ -4662,7 +4659,7 @@ packages:
       webpack: 5.90.3
     dev: true
 
-  /ts-node@10.9.2(@types/node@20.11.20)(typescript@5.3.3):
+  /ts-node@10.9.2(@types/node@20.11.21)(typescript@5.3.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -4681,7 +4678,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -4794,7 +4791,6 @@ packages:
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-    requiresBuild: true
     dependencies:
       punycode: 2.3.1
     dev: true
@@ -4883,7 +4879,7 @@ packages:
     resolution: {integrity: sha512-1/kpZvuftt59oikHs+6FvWXNfOM5tgMMMAk3LnMe7D938dVOoNGAe46fq0oL/xsxxPicbMRTRgIy1OifLiglaA==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/ws': 8.5.10
       '@wdio/config': 8.32.3
       '@wdio/logger': 8.28.0
@@ -4909,7 +4905,7 @@ packages:
       devtools:
         optional: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/config': 8.32.3
       '@wdio/logger': 8.28.0
       '@wdio/protocols': 8.32.0
@@ -5107,7 +5103,6 @@ packages:
   /xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
-    requiresBuild: true
     dev: true
 
   /xmlchars@2.2.0:
@@ -5213,7 +5208,7 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
-  file:..(electron@29.0.1)(webdriverio@8.32.3):
+  file:..(electron@29.1.0)(webdriverio@8.32.3):
     resolution: {directory: .., type: directory}
     id: file:..
     name: wdio-electron-service
@@ -5229,8 +5224,8 @@ packages:
       '@wdio/logger': 8.28.0
       compare-versions: 6.1.0
       debug: 4.3.4(supports-color@8.1.1)
-      electron: 29.0.1
-      electron-to-chromium: 1.4.682
+      electron: 29.1.0
+      electron-to-chromium: 1.4.685
       fast-copy: 3.0.1
       find-versions: 5.1.0
       node-fetch: 3.3.2

--- a/example/e2e/api.spec.ts
+++ b/example/e2e/api.spec.ts
@@ -4,8 +4,6 @@ import type { Mock } from '@vitest/spy';
 
 const { name: pkgAppName, version: pkgAppVersion } = globalThis.packageJson;
 
-// TODO: more use of `await expect(browser.electron.execute((electron) => electron.x.y())).resolves.toBe(z)`
-
 describe('mock', () => {
   it('should mock an electron API function', async () => {
     const mockShowOpenDialog = await browser.electron.mock('dialog', 'showOpenDialog');
@@ -264,7 +262,7 @@ describe('execute', () => {
   });
 
   it('should execute a string-based function in the electron main process', async () => {
-    expect(await browser.electron.execute('return 1 + 2 + 3')).toEqual(6);
+    await expect(browser.electron.execute('return 1 + 2 + 3')).resolves.toEqual(6);
   });
 });
 
@@ -588,9 +586,12 @@ describe('mock object functionality', () => {
       );
 
       expect(withImplementationResult).toBe('temporary mock name');
-      expect(await browser.electron.execute((electron) => electron.app.getName())).toBe('first mock name');
-      expect(await browser.electron.execute((electron) => electron.app.getName())).toBe('second mock name');
-      expect(await browser.electron.execute((electron) => electron.app.getName())).toBe('default mock name');
+      const firstName = await browser.electron.execute((electron) => electron.app.getName());
+      expect(firstName).toBe('first mock name');
+      const secondName = await browser.electron.execute((electron) => electron.app.getName());
+      expect(secondName).toBe('second mock name');
+      const thirdName = await browser.electron.execute((electron) => electron.app.getName());
+      expect(thirdName).toBe('default mock name');
     });
 
     it('should handle promises', async () => {
@@ -604,15 +605,12 @@ describe('mock object functionality', () => {
       );
 
       expect(withImplementationResult).toBe('temporary mock icon');
-      expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
-        'first mock icon',
-      );
-      expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
-        'second mock icon',
-      );
-      expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
-        'default mock icon',
-      );
+      const firstIcon = await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      expect(firstIcon).toBe('first mock icon');
+      const secondIcon = await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      expect(secondIcon).toBe('second mock icon');
+      const thirdIcon = await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      expect(thirdIcon).toBe('default mock icon');
     });
   });
 

--- a/example/e2e/api.spec.ts
+++ b/example/e2e/api.spec.ts
@@ -4,6 +4,8 @@ import type { Mock } from '@vitest/spy';
 
 const { name: pkgAppName, version: pkgAppVersion } = globalThis.packageJson;
 
+// TODO: more use of `await expect(browser.electron.execute((electron) => electron.x.y())).resolves.toBe(z)`
+
 describe('mock', () => {
   it('should mock an electron API function', async () => {
     const mockShowOpenDialog = await browser.electron.mock('dialog', 'showOpenDialog');
@@ -76,13 +78,11 @@ describe('clearAllMocks', () => {
     await browser.electron.clearAllMocks();
 
     expect(mockSetName.mock.calls).toStrictEqual([]);
-    expect(mockSetName.mock.instances).toStrictEqual([]);
     expect(mockSetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockSetName.mock.lastCall).toBeUndefined();
     expect(mockSetName.mock.results).toStrictEqual([]);
 
     expect(mockWriteText.mock.calls).toStrictEqual([]);
-    expect(mockWriteText.mock.instances).toStrictEqual([]);
     expect(mockWriteText.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockWriteText.mock.lastCall).toBeUndefined();
     expect(mockWriteText.mock.results).toStrictEqual([]);
@@ -98,13 +98,11 @@ describe('clearAllMocks', () => {
     await browser.electron.clearAllMocks('app');
 
     expect(mockSetName.mock.calls).toStrictEqual([]);
-    expect(mockSetName.mock.instances).toStrictEqual([]);
     expect(mockSetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockSetName.mock.lastCall).toBeUndefined();
     expect(mockSetName.mock.results).toStrictEqual([]);
 
     expect(mockWriteText.mock.calls).toStrictEqual([['text to be written']]);
-    expect(mockWriteText.mock.instances).toStrictEqual([expect.any(Function)]);
     expect(mockWriteText.mock.invocationCallOrder).toStrictEqual([expect.any(Number)]);
     expect(mockWriteText.mock.lastCall).toStrictEqual(['text to be written']);
     expect(mockWriteText.mock.results).toStrictEqual([{ type: 'return', value: undefined }]);
@@ -174,13 +172,11 @@ describe('resetAllMocks', () => {
     await browser.electron.resetAllMocks('app');
 
     expect(mockSetName.mock.calls).toStrictEqual([]);
-    expect(mockSetName.mock.instances).toStrictEqual([]);
     expect(mockSetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockSetName.mock.lastCall).toBeUndefined();
     expect(mockSetName.mock.results).toStrictEqual([]);
 
     expect(mockWriteText.mock.calls).toStrictEqual([['text to be written']]);
-    expect(mockWriteText.mock.instances).toStrictEqual([expect.any(Function)]);
     expect(mockWriteText.mock.invocationCallOrder).toStrictEqual([expect.any(Number)]);
     expect(mockWriteText.mock.lastCall).toStrictEqual(['text to be written']);
     expect(mockWriteText.mock.results).toStrictEqual([{ type: 'return', value: undefined }]);
@@ -452,7 +448,6 @@ describe('mock object functionality', () => {
       await mockShowOpenDialog.mockClear();
 
       expect(mockShowOpenDialog.mock.calls).toStrictEqual([]);
-      expect(mockShowOpenDialog.mock.instances).toStrictEqual([]);
       expect(mockShowOpenDialog.mock.invocationCallOrder).toStrictEqual([]);
       expect(mockShowOpenDialog.mock.lastCall).toBeUndefined();
       expect(mockShowOpenDialog.mock.results).toStrictEqual([]);
@@ -513,7 +508,6 @@ describe('mock object functionality', () => {
       await mockShowOpenDialog.mockReset();
 
       expect(mockShowOpenDialog.mock.calls).toStrictEqual([]);
-      expect(mockShowOpenDialog.mock.instances).toStrictEqual([]);
       expect(mockShowOpenDialog.mock.invocationCallOrder).toStrictEqual([]);
       expect(mockShowOpenDialog.mock.lastCall).toBeUndefined();
       expect(mockShowOpenDialog.mock.results).toStrictEqual([]);
@@ -619,6 +613,105 @@ describe('mock object functionality', () => {
       expect(await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'))).toBe(
         'default mock icon',
       );
+    });
+  });
+
+  describe('mock.calls', () => {
+    it('should return the calls of the mock execution', async () => {
+      const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+
+      await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      await browser.electron.execute((electron) =>
+        electron.app.getFileIcon('/path/to/another/icon', { size: 'small' }),
+      );
+
+      expect(mockGetFileIcon.mock.calls).toStrictEqual([
+        ['/path/to/icon'], // first call
+        ['/path/to/another/icon', { size: 'small' }], // second call
+      ]);
+    });
+
+    it('should return an empty array when the mock was never invoked', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      expect(mockGetName.mock.calls).toStrictEqual([]);
+    });
+  });
+
+  describe('mock.lastCall', () => {
+    it('should return the last call of the mock execution', async () => {
+      const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+
+      await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+      expect(mockGetFileIcon.mock.lastCall).toStrictEqual(['/path/to/icon']);
+      await browser.electron.execute((electron) =>
+        electron.app.getFileIcon('/path/to/another/icon', { size: 'small' }),
+      );
+      expect(mockGetFileIcon.mock.lastCall).toStrictEqual(['/path/to/another/icon', { size: 'small' }]);
+      await browser.electron.execute((electron) =>
+        electron.app.getFileIcon('/path/to/a/massive/icon', { size: 'large' }),
+      );
+      expect(mockGetFileIcon.mock.lastCall).toStrictEqual(['/path/to/a/massive/icon', { size: 'large' }]);
+    });
+
+    it('should return undefined when the mock was never invoked', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      expect(mockGetName.mock.lastCall).toBeUndefined();
+    });
+  });
+
+  describe('mock.results', () => {
+    it('should return the results of the mock execution', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      // TODO: why does `mockReturnValueOnce` not work for returning 'result' here?
+      await mockGetName.mockImplementationOnce(() => 'result');
+      await mockGetName.mockImplementation(() => {
+        throw new Error('thrown error');
+      });
+
+      await expect(browser.electron.execute((electron) => electron.app.getName())).resolves.toBe('result');
+      await expect(browser.electron.execute((electron) => electron.app.getName())).rejects.toThrow('thrown error');
+
+      expect(mockGetName.mock.results).toStrictEqual([
+        {
+          type: 'return',
+          value: 'result',
+        },
+        {
+          type: 'throw',
+          value: new Error('thrown error'),
+        },
+      ]);
+    });
+
+    it('should return an empty array when the mock was never invoked', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      expect(mockGetName.mock.results).toStrictEqual([]);
+    });
+  });
+
+  describe('mock.invocationCallOrder', () => {
+    it('should return the order of execution', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+      const mockGetVersion = await browser.electron.mock('app', 'getVersion');
+
+      await browser.electron.execute((electron) => electron.app.getName());
+      await browser.electron.execute((electron) => electron.app.getVersion());
+      await browser.electron.execute((electron) => electron.app.getName());
+
+      const firstInvocationIndex = mockGetName.mock.invocationCallOrder[0];
+
+      expect(mockGetName.mock.invocationCallOrder).toStrictEqual([firstInvocationIndex, firstInvocationIndex + 2]);
+      expect(mockGetVersion.mock.invocationCallOrder).toStrictEqual([firstInvocationIndex + 1]);
+    });
+
+    it('should return an empty array when the mock was never invoked', async () => {
+      const mockGetName = await browser.electron.mock('app', 'getName');
+
+      expect(mockGetName.mock.invocationCallOrder).toStrictEqual([]);
     });
   });
 });

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   wdio-electron-service:
     specifier: file:../
-    version: file:..(electron@29.0.1)(webdriverio@8.32.3)
+    version: file:..(electron@29.1.0)(webdriverio@8.32.3)
 
 devDependencies:
   '@electron-forge/cli':
@@ -21,7 +21,7 @@ devDependencies:
     version: 15.2.3(rollup@4.12.0)
   '@types/node':
     specifier: ^20.11.0
-    version: 20.11.20
+    version: 20.11.21
   '@wdio/cli':
     specifier: ^8.27.2
     version: 8.32.3(typescript@5.3.3)
@@ -36,7 +36,7 @@ devDependencies:
     version: 8.32.3
   electron:
     specifier: ^29.0.1
-    version: 29.0.1
+    version: 29.1.0
   global-jsdom:
     specifier: ^24.0.0
     version: 24.0.0(jsdom@24.0.0)
@@ -51,7 +51,7 @@ devDependencies:
     version: 9.5.1(typescript@5.3.3)(webpack@5.90.3)
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.2(@types/node@20.11.20)(typescript@5.3.3)
+    version: 10.9.2(@types/node@20.11.21)(typescript@5.3.3)
   typescript:
     specifier: ^5.3.2
     version: 5.3.3
@@ -71,12 +71,10 @@ packages:
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
-    requiresBuild: true
 
   /@babel/highlight@7.23.4:
     resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
     engines: {node: '>=6.9.0'}
-    requiresBuild: true
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
@@ -488,7 +486,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
@@ -846,18 +844,18 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/responselike': 1.0.3
 
   /@types/eslint-scope@3.7.7:
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
     dependencies:
-      '@types/eslint': 8.56.3
+      '@types/eslint': 8.56.4
       '@types/estree': 1.0.5
     dev: true
 
-  /@types/eslint@8.56.3:
-    resolution: {integrity: sha512-PvSf1wfv2wJpVIFUMSb+i4PvqNYkB9Rkp9ZDO3oaWzq4SKhsQk4mrMBr3ZH06I0hKrVGLBacmgl8JM4WVjb9dg==}
+  /@types/eslint@8.56.4:
+    resolution: {integrity: sha512-lG1GLUnL5vuRBGb3MgWUWLdGMH2Hps+pERuyQXCfWozuGKdnhf9Pbg4pkcrVUHjKrU7Rl+GCZ/299ObBXZFAxg==}
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
@@ -896,14 +894,14 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@types/mocha@10.0.6:
     resolution: {integrity: sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==}
     dev: true
 
-  /@types/node@20.11.20:
-    resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
+  /@types/node@20.11.21:
+    resolution: {integrity: sha512-/ySDLGscFPNasfqStUuWWPfL78jompfIoVzLJPVVAHBh6rpG68+pI2Gk+fNLeI8/f1yPYL4s46EleVIc20F1Ow==}
     dependencies:
       undici-types: 5.26.5
 
@@ -917,7 +915,7 @@ packages:
   /@types/responselike@1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -930,7 +928,7 @@ packages:
   /@types/ws@8.5.10:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -948,7 +946,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     optional: true
 
   /@vitest/snapshot@1.3.1:
@@ -970,7 +968,7 @@ packages:
     engines: {node: ^16.13 || >=18}
     hasBin: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@vitest/snapshot': 1.3.1
       '@wdio/config': 8.32.3
       '@wdio/globals': 8.32.3(typescript@5.3.3)
@@ -1036,7 +1034,7 @@ packages:
     resolution: {integrity: sha512-YgqYkKarx2m9OjA8WO4NqQPCfFNLmZHnuEWQ6P2LqUeYFsdXRd3wR3UTo9XrI23VSQo+kcpqInsR5vLOYDd1zg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/logger': 8.28.0
       '@wdio/repl': 8.24.12
       '@wdio/runner': 8.32.3(typescript@5.3.3)
@@ -1067,7 +1065,7 @@ packages:
     engines: {node: ^16.13 || >=18}
     dependencies:
       '@types/mocha': 10.0.6
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/logger': 8.28.0
       '@wdio/types': 8.32.2
       '@wdio/utils': 8.32.3
@@ -1083,13 +1081,13 @@ packages:
     resolution: {integrity: sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@wdio/runner@8.32.3(typescript@5.3.3):
     resolution: {integrity: sha512-HlhdQ4lJ07seL7/x0UQPDnK+o5a0okyjd8ukFYqDL+g9+d3KlW/oM3NvFfX7pb9liIYNEpmoNMwKFp+5XPUE7w==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/config': 8.32.3
       '@wdio/globals': 8.32.3(typescript@5.3.3)
       '@wdio/logger': 8.28.0
@@ -1113,7 +1111,7 @@ packages:
     resolution: {integrity: sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
 
   /@wdio/utils@8.32.3:
     resolution: {integrity: sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==}
@@ -1349,7 +1347,6 @@ packages:
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
-    requiresBuild: true
     dependencies:
       color-convert: 1.9.3
 
@@ -1493,8 +1490,8 @@ packages:
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  /basic-ftp@5.0.4:
-    resolution: {integrity: sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==}
+  /basic-ftp@5.0.5:
+    resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
 
   /big-integer@1.6.52:
@@ -1560,7 +1557,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001591
-      electron-to-chromium: 1.4.682
+      electron-to-chromium: 1.4.685
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
     dev: true
@@ -1677,7 +1674,6 @@ packages:
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
-    requiresBuild: true
     dependencies:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
@@ -1810,7 +1806,6 @@ packages:
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-    requiresBuild: true
     dependencies:
       color-name: 1.1.3
 
@@ -1822,7 +1817,6 @@ packages:
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-    requiresBuild: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -2156,17 +2150,17 @@ packages:
       jake: 10.8.7
     dev: true
 
-  /electron-to-chromium@1.4.682:
-    resolution: {integrity: sha512-oCglfs8yYKs9RQjJFOHonSnhikPK3y+0SvSYc/YpYJV//6rqc0/hbwd0c7vgK4vrl6y2gJAwjkhkSGWK+z4KRA==}
+  /electron-to-chromium@1.4.685:
+    resolution: {integrity: sha512-yDYeobbTEe4TNooEzOQO6xFqg9XnAkVy2Lod1C1B2it8u47JNLYvl9nLDWBamqUakWB8Jc1hhS1uHUNYTNQdfw==}
 
-  /electron@29.0.1:
-    resolution: {integrity: sha512-hsQr9clm8NCAMv4uhHlXThHn52UAgrHgyz3ubBAxZIPuUcpKVDtg4HPmx4hbmHIbYICI5OyLN3Ztp7rS+Dn4Lw==}
+  /electron@29.1.0:
+    resolution: {integrity: sha512-giJVIm0sWVp+8V1GXrKqKTb+h7no0P3ooYqEd34AD9wMJzGnAeL+usj+R0155/0pdvvP1mgydnA7lcaFA2M9lw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -2748,7 +2742,7 @@ packages:
     resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
     engines: {node: '>= 14'}
     dependencies:
-      basic-ftp: 5.0.4
+      basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
       debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 11.2.0
@@ -2913,7 +2907,6 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
-    requiresBuild: true
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3321,7 +3314,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3332,14 +3325,13 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    requiresBuild: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -5043,7 +5035,6 @@ packages:
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
-    requiresBuild: true
     dependencies:
       has-flag: 3.0.0
 
@@ -5211,7 +5202,7 @@ packages:
       webpack: 5.90.3
     dev: true
 
-  /ts-node@10.9.2(@types/node@20.11.20)(typescript@5.3.3):
+  /ts-node@10.9.2(@types/node@20.11.21)(typescript@5.3.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -5230,7 +5221,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -5422,7 +5413,7 @@ packages:
     resolution: {integrity: sha512-1/kpZvuftt59oikHs+6FvWXNfOM5tgMMMAk3LnMe7D938dVOoNGAe46fq0oL/xsxxPicbMRTRgIy1OifLiglaA==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/ws': 8.5.10
       '@wdio/config': 8.32.3
       '@wdio/logger': 8.28.0
@@ -5447,7 +5438,7 @@ packages:
       devtools:
         optional: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/config': 8.32.3
       '@wdio/logger': 8.28.0
       '@wdio/protocols': 8.32.0
@@ -5755,7 +5746,7 @@ packages:
       compress-commons: 5.0.3
       readable-stream: 3.6.2
 
-  file:..(electron@29.0.1)(webdriverio@8.32.3):
+  file:..(electron@29.1.0)(webdriverio@8.32.3):
     resolution: {directory: .., type: directory}
     id: file:..
     name: wdio-electron-service
@@ -5771,8 +5762,8 @@ packages:
       '@wdio/logger': 8.28.0
       compare-versions: 6.1.0
       debug: 4.3.4(supports-color@8.1.1)
-      electron: 29.0.1
-      electron-to-chromium: 1.4.682
+      electron: 29.1.0
+      electron-to-chromium: 1.4.685
       fast-copy: 3.0.1
       find-versions: 5.1.0
       node-fetch: 3.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ dependencies:
     version: 4.3.4
   electron-to-chromium:
     specifier: ^1.4.630
-    version: 1.4.682
+    version: 1.4.685
   fast-copy:
     specifier: ^3.0.1
     version: 3.0.1
@@ -51,7 +51,7 @@ devDependencies:
     version: 10.0.6
   '@types/node':
     specifier: ^20.11.0
-    version: 20.11.20
+    version: 20.11.21
   '@typescript-eslint/eslint-plugin':
     specifier: ^7.0.1
     version: 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.57.0)(typescript@5.3.3)
@@ -75,7 +75,7 @@ devDependencies:
     version: 7.0.3
   electron:
     specifier: ^29.0.1
-    version: 29.0.1
+    version: 29.1.0
   eslint:
     specifier: ^8.55.0
     version: 8.57.0
@@ -126,7 +126,7 @@ devDependencies:
     version: 5.3.3
   vitest:
     specifier: ^1.2.0
-    version: 1.3.1(@types/node@20.11.20)(jsdom@24.0.0)
+    version: 1.3.1(@types/node@20.11.21)(jsdom@24.0.0)
   webdriverio:
     specifier: ^8.27.2
     version: 8.32.3(typescript@5.3.3)
@@ -170,23 +170,23 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser@7.23.9:
-    resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
+  /@babel/parser@7.24.0:
+    resolution: {integrity: sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
-  /@babel/runtime@7.23.9:
-    resolution: {integrity: sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==}
+  /@babel/runtime@7.24.0:
+    resolution: {integrity: sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
     dev: true
 
-  /@babel/types@7.23.9:
-    resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
+  /@babel/types@7.24.0:
+    resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.23.4
@@ -521,7 +521,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
@@ -895,7 +895,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/code-frame': 7.23.5
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.24.0
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -909,7 +909,7 @@ packages:
     peerDependencies:
       webdriverio: '*'
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.24.0
       '@testing-library/dom': 8.20.1
       simmerjs: 0.5.6
       webdriverio: 8.32.3(typescript@5.3.3)
@@ -928,7 +928,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/responselike': 1.0.3
     dev: true
 
@@ -973,7 +973,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@types/mocha@10.0.6:
@@ -984,8 +984,8 @@ packages:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: true
 
-  /@types/node@20.11.20:
-    resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
+  /@types/node@20.11.21:
+    resolution: {integrity: sha512-/ySDLGscFPNasfqStUuWWPfL78jompfIoVzLJPVVAHBh6rpG68+pI2Gk+fNLeI8/f1yPYL4s46EleVIc20F1Ow==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -996,7 +996,7 @@ packages:
   /@types/responselike@1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@types/semver@7.5.8:
@@ -1014,7 +1014,7 @@ packages:
   /@types/ws@8.5.10:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@types/yargs-parser@21.0.3:
@@ -1031,7 +1031,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
     optional: true
 
@@ -1251,7 +1251,7 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.3.1(@types/node@20.11.20)(jsdom@24.0.0)
+      vitest: 1.3.1(@types/node@20.11.21)(jsdom@24.0.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1299,7 +1299,7 @@ packages:
     engines: {node: ^16.13 || >=18}
     hasBin: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@vitest/snapshot': 1.3.1
       '@wdio/config': 8.32.3
       '@wdio/globals': 8.32.3(typescript@5.3.3)
@@ -1379,14 +1379,14 @@ packages:
     resolution: {integrity: sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@wdio/types@8.32.2:
     resolution: {integrity: sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
     dev: true
 
   /@wdio/utils@8.32.3:
@@ -1666,8 +1666,8 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: true
 
-  /basic-ftp@5.0.4:
-    resolution: {integrity: sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==}
+  /basic-ftp@5.0.5:
+    resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
     dev: true
 
@@ -2195,7 +2195,7 @@ packages:
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.3
       isarray: 2.0.5
-      object-is: 1.1.5
+      object-is: 1.1.6
       object-keys: 1.1.1
       object.assign: 4.1.5
       regexp.prototype.flags: 1.5.2
@@ -2377,18 +2377,18 @@ packages:
       jake: 10.8.7
     dev: true
 
-  /electron-to-chromium@1.4.682:
-    resolution: {integrity: sha512-oCglfs8yYKs9RQjJFOHonSnhikPK3y+0SvSYc/YpYJV//6rqc0/hbwd0c7vgK4vrl6y2gJAwjkhkSGWK+z4KRA==}
+  /electron-to-chromium@1.4.685:
+    resolution: {integrity: sha512-yDYeobbTEe4TNooEzOQO6xFqg9XnAkVy2Lod1C1B2it8u47JNLYvl9nLDWBamqUakWB8Jc1hhS1uHUNYTNQdfw==}
     dev: false
 
-  /electron@29.0.1:
-    resolution: {integrity: sha512-hsQr9clm8NCAMv4uhHlXThHn52UAgrHgyz3ubBAxZIPuUcpKVDtg4HPmx4hbmHIbYICI5OyLN3Ztp7rS+Dn4Lw==}
+  /electron@29.1.0:
+    resolution: {integrity: sha512-giJVIm0sWVp+8V1GXrKqKTb+h7no0P3ooYqEd34AD9wMJzGnAeL+usj+R0155/0pdvvP1mgydnA7lcaFA2M9lw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -2626,7 +2626,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
-      vitest: 1.3.1(@types/node@20.11.20)(jsdom@24.0.0)
+      vitest: 1.3.1(@types/node@20.11.21)(jsdom@24.0.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3130,7 +3130,7 @@ packages:
     resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
     engines: {node: '>= 14'}
     dependencies:
-      basic-ftp: 5.0.4
+      basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
       debug: 4.3.4
       fs-extra: 11.2.0
@@ -3998,7 +3998,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -4371,8 +4371,8 @@ packages:
   /magicast@0.3.3:
     resolution: {integrity: sha512-ZbrP1Qxnpoes8sz47AM0z08U+jW6TyRgZzcWy3Ma3vDhJttwMwAFDMMQFobwdBxByBD46JYmxRzeF7w2+wJEuw==}
     dependencies:
-      '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.24.0
+      '@babel/types': 7.24.0
       source-map-js: 1.0.2
     dev: true
 
@@ -4614,8 +4614,8 @@ packages:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
     dev: true
 
-  /object-is@1.1.5:
-    resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
+  /object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
@@ -6260,7 +6260,7 @@ packages:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  /vite-node@1.3.1(@types/node@20.11.20):
+  /vite-node@1.3.1(@types/node@20.11.21):
     resolution: {integrity: sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -6269,7 +6269,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.4(@types/node@20.11.20)
+      vite: 5.1.4(@types/node@20.11.21)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6281,7 +6281,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.1.4(@types/node@20.11.20):
+  /vite@5.1.4(@types/node@20.11.21):
     resolution: {integrity: sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -6309,7 +6309,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       esbuild: 0.19.12
       postcss: 8.4.35
       rollup: 4.12.0
@@ -6317,7 +6317,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.3.1(@types/node@20.11.20)(jsdom@24.0.0):
+  /vitest@1.3.1(@types/node@20.11.21)(jsdom@24.0.0):
     resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -6342,7 +6342,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@vitest/expect': 1.3.1
       '@vitest/runner': 1.3.1
       '@vitest/snapshot': 1.3.1
@@ -6361,8 +6361,8 @@ packages:
       strip-literal: 2.0.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.1.4(@types/node@20.11.20)
-      vite-node: 1.3.1(@types/node@20.11.20)
+      vite: 5.1.4(@types/node@20.11.21)
+      vite-node: 1.3.1(@types/node@20.11.21)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -6407,7 +6407,7 @@ packages:
     resolution: {integrity: sha512-1/kpZvuftt59oikHs+6FvWXNfOM5tgMMMAk3LnMe7D938dVOoNGAe46fq0oL/xsxxPicbMRTRgIy1OifLiglaA==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@types/ws': 8.5.10
       '@wdio/config': 8.32.3
       '@wdio/logger': 8.28.0
@@ -6433,7 +6433,7 @@ packages:
       devtools:
         optional: true
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.21
       '@wdio/config': 8.32.3
       '@wdio/logger': 8.28.0
       '@wdio/protocols': 8.32.0

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,18 +182,99 @@ export type WdioElectronWindowObj = {
   execute: (script: string, args?: unknown[]) => unknown;
 };
 
-// TODO: replace unknowns in `mockReturnValue`, calls, results, lastCall, etc. to stop users passing functions
+enum ElectronMockResultType {
+  Return = 'return',
+  Throw = 'throw',
+}
 
 type ElectronMockResult = {
-  type: 'return' | 'throw';
+  type: ElectronMockResultType;
   value: unknown;
 };
 
-// TODO: doc comments here
 interface ElectronMockContext {
+  /**
+   * This is an array containing all arguments for each call. Each item of the array is the arguments of that call.
+   *
+   * @example
+   * ```js
+   * const mockGetFileIcon = await browser.electron.mock('app', 'getFileIcon');
+   *
+   * await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/icon'));
+   * await browser.electron.execute((electron) => electron.app.getFileIcon('/path/to/another/icon', { size: 'small' }));
+   *
+   * expect(mockGetFileIcon.mock.calls).toStrictEqual([
+   *   ['/path/to/icon'], // first call
+   *   ['/path/to/another/icon', { size: 'small' }], // second call
+   * ]);
+   * ```
+   */
   calls: unknown[][];
+  /**
+   * The order of mock invocation. This returns an array of numbers that are shared between all defined mocks. Will return an empty array if the mock was never invoked.
+   *
+   * @example
+   * ```js
+   * const mockGetName = await browser.electron.mock('app', 'getName');
+   * const mockGetVersion = await browser.electron.mock('app', 'getVersion');
+   *
+   * await browser.electron.execute((electron) => electron.app.getName());
+   * await browser.electron.execute((electron) => electron.app.getVersion());
+   * await browser.electron.execute((electron) => electron.app.getName());
+   *
+   * expect(mockGetName.mock.invocationCallOrder).toStrictEqual([1, 3]);
+   * expect(mockGetVersion.mock.invocationCallOrder).toStrictEqual([2]);
+   * ```
+   */
   invocationCallOrder: number[];
+  /**
+   * This is an array containing all values that were returned from the mock. Each item of the array is an object with the properties type and value. Available types are:
+   *
+   *     'return' - the mock returned without throwing.
+   *     'throw' - the mock threw a value.
+   *
+   * The value property contains the returned value or the thrown error. If the mock returned a promise, the value will be the resolved value, not the Promise itself, unless it was never resolved.
+   *
+   * @example
+   * ```js
+   * const mockGetName = await browser.electron.mock('app', 'getName');
+   *
+   * await mockGetName.mockImplementationOnce(() => 'result');
+   * await mockGetName.mockImplementation(() => {
+   *   throw new Error('thrown error');
+   * });
+   *
+   * await expect(browser.electron.execute((electron) => electron.app.getName())).resolves.toBe('result');
+   * await expect(browser.electron.execute((electron) => electron.app.getName())).rejects.toThrow('thrown error');
+   *
+   * expect(mockGetName.mock.results).toStrictEqual([
+   *   {
+   *     type: 'return',
+   *     value: 'result',
+   *   },
+   *   {
+   *     type: 'throw',
+   *     value: new Error('thrown error'),
+   *   },
+   * ]);
+   * ```
+   */
   results: ElectronMockResult[];
+  /**
+   * This contains the arguments of the last call. If the mock wasn't called, it will return `undefined`.
+   *
+   * @example
+   * ```js
+   * const mockSetName = await browser.electron.mock('app', 'setName');
+   *
+   * await browser.electron.execute((electron) => electron.app.setName('test'));
+   * expect(mockSetName.mock.lastCall).toStrictEqual(['test']);
+   * await browser.electron.execute((electron) => electron.app.setName('test 2'));
+   * expect(mockSetName.mock.lastCall).toStrictEqual(['test 2']);
+   * await browser.electron.execute((electron) => electron.app.setName('test 3'));
+   * expect(mockSetName.mock.lastCall).toStrictEqual(['test 3']);
+   * ```
+   */
   lastCall: unknown;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,21 @@ export type WdioElectronWindowObj = {
   execute: (script: string, args?: unknown[]) => unknown;
 };
 
+// TODO: replace unknowns in `mockReturnValue`, calls, results, lastCall, etc. to stop users passing functions
+
+type ElectronMockResult = {
+  type: 'return' | 'throw';
+  value: unknown;
+};
+
+// TODO: doc comments here
+interface ElectronMockContext {
+  calls: unknown[][];
+  invocationCallOrder: number[];
+  results: ElectronMockResult[];
+  lastCall: unknown;
+}
+
 type Override =
   | 'mockImplementation'
   | 'mockImplementationOnce'
@@ -195,7 +210,8 @@ type Override =
   | 'mockReset'
   | 'mockReturnThis'
   | 'mockName'
-  | 'withImplementation';
+  | 'withImplementation'
+  | 'mock';
 
 interface ElectronMockInstance extends Omit<Mock, Override> {
   /**
@@ -511,6 +527,10 @@ interface ElectronMockInstance extends Omit<Mock, Override> {
    * Used internally to update the outer mock function with calls from the inner (Electron context) mock.
    */
   update(): Promise<ElectronMock>;
+  /**
+   * Current context of the mock. It stores information about all invocation calls and results.
+   */
+  mock: ElectronMockContext;
 }
 
 export interface ElectronMock<TArgs extends any[] = any, TReturns = any> extends ElectronMockInstance {


### PR DESCRIPTION
Adding mock object properties (E2Es, docs, updating types).  Including `calls`, `lastCall`, `results`, `invocationCallOrder`.  Not including [`instances`](https://vitest.dev/api/mock.html#mock-instances) as our mocks are instantiated solely via `createMock`, without using `new`.