### PR TITLE
ci: Add pre-release to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: Manual NPM Publish
 
 on:
@@ -13,7 +14,7 @@ on:
           - minor
           - major
       distTag:
-        description: 'NPM tag (e.g. use "next" to release a test version)'
+        description: 'NPM tag (e.g. use "next" to release a test (pre-release) version)'
         required: true
         default: 'latest'
 
@@ -48,8 +49,17 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm build
+
+      - name: Pre-release
+        if: ${{ inputs.distTag != 'latest' }}
+        run: pnpm run release:ci ${{inputs.releaseType}} --preRelease=${{inputs.distTag}}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Release
-        run: pnpm run release:ci --npm.tag=${{github.event.inputs.distTag}} -- ${{github.event.inputs.releaseType}}
+        if: ${{ inputs.distTag == 'latest' }}
+        run: pnpm run release:ci ${{inputs.releaseType}} --npm.tag=${{inputs.distTag}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,13 +81,13 @@ Check the issues or [raise a new one](https://github.com/webdriverio-community/w
 
 Project maintainers can publish a release or pre-release of the npm package by manually running the [`Manual NPM Publish`](https://github.com/webdriverio-community/wdio-electron-service/actions/workflows/release.yml) GitHub Workflow. They will choose the release type to trigger a `major` , `minor`, or `patch` release following [Semantic Versioning](https://semver.org/).
 
-To publish a release, run the Workflow with default **Branch** `main` and **NPM Tag** `latest` and the appropriate **Release Type**. This will:
+To publish a release, run the Workflow with defaults for **Branch** `main` and **NPM Tag** `latest`, and the appropriate **Release Type**. This will:
 
 * Create a Git tag
 * Create a GitHub Release
 * Publish to npm
 
-To publish a pre-release, also referred to as a test release, run the Workflow with the **NPM Tag** `next`. This will:
+To publish a pre-release, also referred to as a test release, run the Workflow with the **Release Type** `patch` and the **NPM Tag** `next`. This will:
 
 * Create a Git tag with the `-next.0` suffix. Consecutive pre-releases will increment the last number.
 * Create a GitHub Pre-Release

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,3 +76,21 @@ Check the issues or [raise a new one](https://github.com/webdriverio-community/w
 
 **[Help Wanted Issues](https://github.com/webdriverio-community/wdio-electron-service/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22)** \
 **[Good First Issues](https://github.com/webdriverio-community/wdio-electron-service/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22)**
+
+## Release
+
+Project maintainers can publish a release or pre-release of the npm package by manually running the [`Manual NPM Publish`](https://github.com/webdriverio-community/wdio-electron-service/actions/workflows/release.yml) GitHub Workflow. They will choose the release type to trigger a `major` , `minor`, or `patch` release following [Semantic Versioning](https://semver.org/).
+
+To publish a release, run the Workflow with default **Branch** `main` and **NPM Tag** `latest` and the appropriate **Release Type**. This will:
+
+* Create a Git tag
+* Create a GitHub Release
+* Publish to npm
+
+To publish a pre-release, also referred to as a test release, run the Workflow with the **NPM Tag** `next`. This will:
+
+* Create a Git tag with the `-next.0` suffix. Consecutive pre-releases will increment the last number.
+* Create a GitHub Pre-Release
+* Publish to npm
+
+The workflow uses [`release-it`](https://github.com/release-it/release-it?tab=readme-ov-file#release-it-) to do most of the work for us.

--- a/docs/development.md
+++ b/docs/development.md
@@ -83,14 +83,14 @@ Project maintainers can publish a release or pre-release of the npm package by m
 
 To publish a release, run the Workflow with defaults for **Branch** `main` and **NPM Tag** `latest`, and the appropriate **Release Type**. This will:
 
-* Create a Git tag
-* Create a GitHub Release
-* Publish to npm
+- Create a Git tag
+- Create a GitHub Release
+- Publish to npm
 
 To publish a pre-release, also referred to as a test release, run the Workflow with the **Release Type** `patch` and the **NPM Tag** `next`. This will:
 
-* Create a Git tag with the `-next.0` suffix. Consecutive pre-releases will increment the last number.
-* Create a GitHub Pre-Release
-* Publish to npm
+- Create a Git tag with the `-next.0` suffix. Consecutive pre-releases will increment the last number.
+- Create a GitHub Pre-Release
+- Publish to npm
 
 The workflow uses [`release-it`](https://github.com/release-it/release-it?tab=readme-ov-file#release-it-) to do most of the work for us.


### PR DESCRIPTION
### Proposed Changes

- Release when we publish `latest`
- Pre-release when we publish `next` (or not `latest`)
- Document the release process
﻿
### Notes

- I didn't quote the workflow inputs so we can still add `--dry-run`.
