### PR TITLE
(fix): update scripts & docs for Husky v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 pnpx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 pnpm test:unit

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,7 @@ To start with development, use e.g. [NVM](https://github.com/nvm-sh/nvm) to inst
 pnpm init-dev
 ```
 
-This will initialise the repo and set up `husky`, which is used for git commit hooks in combination with `lint-staged`.
+This will initialise the repo for development, installing all sub-packages. [Husky](https://typicode.github.io/husky/) is used for git commit hooks in combination with [`lint-staged`](https://github.com/lint-staged/lint-staged).
 
 ## Testing
 
@@ -44,7 +44,9 @@ pnpm update:all
 
 ## Formatting
 
-The repo uses [Prettier](https://prettier.io) for formatting. It is encouraged to format code on save using, e.g. the [Prettier plugin for VSCode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode), however Prettier is configured to run on git pre-commit hook to ensure consistent formatting across the repo. Prettier can be invoked manually via:
+The repo uses [Prettier](https://prettier.io) for formatting. It is encouraged to format code on save using, e.g. the [Prettier plugin for VSCode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode), however it is not a requirement; Husky is configured to run Prettier on git pre-commit hook to ensure consistent formatting across the repo.
+
+Prettier can be invoked manually via:
 
 ```bash
 pnpm format

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "node": "^16.13 || >=18 || >=20"
   },
   "scripts": {
-    "init-dev": "pnpm i --filter=\\!fixture-\\* -r && husky install",
+    "prepare": "husky",
+    "init-dev": "pnpm i --filter=\\!fixture-\\* -r",
     "ci": "pnpm i && pnpm build && pnpm test && pnpm lint && pnpm format:check",
     "clean": "pnpx rimraf ./node_modules pnpm-lock.yaml ./dist ./src/cjs/preload.ts ./src/cjs/main.ts ./src/cjs/constants.ts ./src/cjs/types.ts",
     "clean:dist": "pnpx rimraf ./dist",


### PR DESCRIPTION
Husky was updated but `husky install` was deprecated, this PR fixes the scripts to run Husky on `prepare` and updates the docs accordingly.

https://github.com/typicode/husky/releases/tag/v9.0.1