### PR TITLE
(feat): isMockFunction command

### DIFF
--- a/@types/vitest/index.d.ts
+++ b/@types/vitest/index.d.ts
@@ -1,5 +1,4 @@
-import vitest from 'vitest';
-
+export * from 'vitest';
 interface CustomMatchers<R = unknown> {
   anyMockFunction(): R;
 }

--- a/docs/electron-apis/mocking-apis.md
+++ b/docs/electron-apis/mocking-apis.md
@@ -135,6 +135,16 @@ expect(appName).toBe('my real app name');
 expect(clipboardText).toBe('mocked clipboardText');
 ```
 
+### `isMockFunction`
+
+Checks that a given parameter is an Electron mock function. If you are using TypeScript, it will also narrow down its type.
+
+```js
+const mockGetName = await browser.electron.mock('app', 'getName');
+
+expect(browser.electron.isMockFunction(mockGetName)).toBe(true);
+```
+
 ## Mock Object
 
 Each mock object has the following methods available:

--- a/example-cjs/e2e/api.spec.ts
+++ b/example-cjs/e2e/api.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest';
 import { expect } from '@wdio/globals';
 import { browser } from 'wdio-electron-service';
 import type { Mock } from '@vitest/spy';
@@ -257,7 +256,12 @@ describe('isMockFunction', () => {
   });
 
   it('should return false when provided with a vitest mock', async () => {
-    expect(vi.fn()).toBe(false);
+    // We have to dynamic import `@vitest/spy` due to it being an ESM only module
+    // To avoid ts-node transforming this import into a `require` we abstract it using `Function`
+    // https://github.com/TypeStrong/ts-node/discussions/1290
+    const dynamicImport = new Function('specifier', 'return import(specifier)');
+    const spy = await dynamicImport('@vitest/spy');
+    expect(browser.electron.isMockFunction(spy.fn())).toBe(false);
   });
 });
 

--- a/example-cjs/e2e/api.spec.ts
+++ b/example-cjs/e2e/api.spec.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { expect } from '@wdio/globals';
 import { browser } from 'wdio-electron-service';
 import type { Mock } from '@vitest/spy';
@@ -148,13 +149,11 @@ describe('resetAllMocks', () => {
     await browser.electron.resetAllMocks();
 
     expect(mockGetName.mock.calls).toStrictEqual([]);
-    expect(mockGetName.mock.instances).toStrictEqual([]);
     expect(mockGetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockGetName.mock.lastCall).toBeUndefined();
     expect(mockGetName.mock.results).toStrictEqual([]);
 
     expect(mockReadText.mock.calls).toStrictEqual([]);
-    expect(mockReadText.mock.instances).toStrictEqual([]);
     expect(mockReadText.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockReadText.mock.lastCall).toBeUndefined();
     expect(mockReadText.mock.results).toStrictEqual([]);
@@ -243,6 +242,22 @@ describe('restoreAllMocks', () => {
     const clipboardText = await browser.electron.execute((electron) => electron.clipboard.readText());
     expect(appName).toBe(pkgAppName);
     expect(clipboardText).toBe('mocked clipboardText');
+  });
+});
+
+describe('isMockFunction', () => {
+  it('should return true when provided with an electron mock', async () => {
+    const mockGetName = await browser.electron.mock('app', 'getName');
+
+    expect(browser.electron.isMockFunction(mockGetName)).toBe(true);
+  });
+
+  it('should return false when provided with a function', async () => {
+    expect(browser.electron.isMockFunction(() => {})).toBe(false);
+  });
+
+  it('should return false when provided with a vitest mock', async () => {
+    expect(vi.fn()).toBe(false);
   });
 });
 

--- a/example/e2e/api.spec.ts
+++ b/example/e2e/api.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest';
 import { expect } from '@wdio/globals';
 import { browser } from 'wdio-electron-service';
 import type { Mock } from '@vitest/spy';
@@ -257,7 +256,12 @@ describe('isMockFunction', () => {
   });
 
   it('should return false when provided with a vitest mock', async () => {
-    expect(vi.fn()).toBe(false);
+    // We have to dynamic import `@vitest/spy` due to it being an ESM only module
+    // To avoid ts-node transforming this import into a `require` we abstract it using `Function`
+    // https://github.com/TypeStrong/ts-node/discussions/1290
+    const dynamicImport = new Function('specifier', 'return import(specifier)');
+    const spy = await dynamicImport('@vitest/spy');
+    expect(browser.electron.isMockFunction(spy.fn())).toBe(false);
   });
 });
 

--- a/example/e2e/api.spec.ts
+++ b/example/e2e/api.spec.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { expect } from '@wdio/globals';
 import { browser } from 'wdio-electron-service';
 import type { Mock } from '@vitest/spy';
@@ -148,13 +149,11 @@ describe('resetAllMocks', () => {
     await browser.electron.resetAllMocks();
 
     expect(mockGetName.mock.calls).toStrictEqual([]);
-    expect(mockGetName.mock.instances).toStrictEqual([]);
     expect(mockGetName.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockGetName.mock.lastCall).toBeUndefined();
     expect(mockGetName.mock.results).toStrictEqual([]);
 
     expect(mockReadText.mock.calls).toStrictEqual([]);
-    expect(mockReadText.mock.instances).toStrictEqual([]);
     expect(mockReadText.mock.invocationCallOrder).toStrictEqual([]);
     expect(mockReadText.mock.lastCall).toBeUndefined();
     expect(mockReadText.mock.results).toStrictEqual([]);
@@ -243,6 +242,22 @@ describe('restoreAllMocks', () => {
     const clipboardText = await browser.electron.execute((electron) => electron.clipboard.readText());
     expect(appName).toBe(pkgAppName);
     expect(clipboardText).toBe('mocked clipboardText');
+  });
+});
+
+describe('isMockFunction', () => {
+  it('should return true when provided with an electron mock', async () => {
+    const mockGetName = await browser.electron.mock('app', 'getName');
+
+    expect(browser.electron.isMockFunction(mockGetName)).toBe(true);
+  });
+
+  it('should return false when provided with a function', async () => {
+    expect(browser.electron.isMockFunction(() => {})).toBe(false);
+  });
+
+  it('should return false when provided with a vitest mock', async () => {
+    expect(vi.fn()).toBe(false);
   });
 });
 

--- a/src/commands/isMockFunction.ts
+++ b/src/commands/isMockFunction.ts
@@ -1,6 +1,7 @@
-import { vi } from 'vitest';
-import { ElectronMockInstance } from 'src/types.js';
+import type { ElectronMockInstance } from 'src/types.js';
 
 export function isMockFunction(fn: unknown): fn is ElectronMockInstance {
-  return vi.isMockFunction(fn) && '__isElectronMock' in fn;
+  return (
+    typeof fn === 'function' && '__isElectronMock' in fn && (fn as unknown as ElectronMockInstance).__isElectronMock
+  );
 }

--- a/src/commands/isMockFunction.ts
+++ b/src/commands/isMockFunction.ts
@@ -1,0 +1,6 @@
+import { vi } from 'vitest';
+import { ElectronMockInstance } from 'src/types.js';
+
+export function isMockFunction(fn: unknown): fn is ElectronMockInstance {
+  return vi.isMockFunction(fn) && '__isElectronMock' in fn;
+}

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -29,6 +29,8 @@ export async function createMock(apiName: string, funcName: string) {
 
   const mock = outerMock as unknown as ElectronMock;
 
+  mock.__isElectronMock = true;
+
   // initialise inner (Electron) mock
   await browser.electron.execute<void, [string, string, ExecuteOpts]>(
     async (electron, apiName, funcName) => {

--- a/src/service.ts
+++ b/src/service.ts
@@ -6,6 +6,7 @@ import { CUSTOM_CAPABILITY_NAME } from './constants.js';
 import { execute } from './commands/execute.js';
 import { mock } from './commands/mock.js';
 import { clearAllMocks } from './commands/clearAllMocks.js';
+import { isMockFunction } from './commands/isMockFunction.js';
 import { resetAllMocks } from './commands/resetAllMocks.js';
 import { restoreAllMocks } from './commands/restoreAllMocks.js';
 import { mockAll } from './commands/mockAll.js';
@@ -44,6 +45,7 @@ export default class ElectronWorkerService implements Services.ServiceInstance {
     const api = {
       clearAllMocks: clearAllMocks.bind(this),
       execute: (script: string | AbstractFn, ...args: unknown[]) => execute.apply(this, [browser, script, ...args]),
+      isMockFunction: isMockFunction.bind(this),
       mock: mock.bind(this),
       mockAll: mockAll.bind(this),
       resetAllMocks: resetAllMocks.bind(this),

--- a/src/types.ts
+++ b/src/types.ts
@@ -628,7 +628,7 @@ export interface ElectronMockInstance extends Omit<Mock, Override> {
   /**
    * Used internally to distinguish the electron mock from other mocks.
    */
-  __isElectronMock: true;
+  __isElectronMock: boolean;
 }
 
 export interface ElectronMock<TArgs extends any[] = any, TReturns = any> extends ElectronMockInstance {

--- a/src/types.ts
+++ b/src/types.ts
@@ -619,6 +619,8 @@ export interface ElectronMockInstance extends Omit<Mock, Override> {
   getMockImplementation(): AbstractFn;
   /**
    * Used internally to update the outer mock function with calls from the inner (Electron context) mock.
+   *
+   * @private
    */
   update(): Promise<ElectronMock>;
   /**
@@ -627,6 +629,8 @@ export interface ElectronMockInstance extends Omit<Mock, Override> {
   mock: ElectronMockContext;
   /**
    * Used internally to distinguish the electron mock from other mocks.
+   *
+   * @private
    */
   __isElectronMock: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type * as Electron from 'electron';
 import type { Mock } from '@vitest/spy';
 
 /**
- * set this environment variable so that the preload script can be loaded
+ * Set this environment variable so that the preload script can be loaded
  */
 process.env.WDIO_ELECTRON = 'true';
 
@@ -14,6 +14,7 @@ export type ElectronApiFn = ElectronType[ElectronInterface][keyof ElectronType[E
 export interface ElectronServiceAPI {
   /**
    * Mock a function from the Electron API.
+   *
    * @param apiName name of the API to mock
    * @param funcName name of the function to mock
    * @param mockReturnValue value to return when the mocked function is called
@@ -43,6 +44,7 @@ export interface ElectronServiceAPI {
   ) => Promise<ElectronMock>;
   /**
    * Mock all functions from an Electron API.
+   *
    * @param apiName name of the API to mock
    * @returns a {@link Promise} that resolves once the mock is registered
    *
@@ -79,7 +81,7 @@ export interface ElectronServiceAPI {
     ...args: InnerArguments
   ): Promise<ReturnValue>;
   /**
-   * Clear mocked Electron API function(s)
+   * Clear mocked Electron API function(s).
    *
    * @example
    * ```js
@@ -93,7 +95,7 @@ export interface ElectronServiceAPI {
    */
   clearAllMocks: (apiName?: string) => Promise<void>;
   /**
-   * Reset mocked Electron API function(s)
+   * Reset mocked Electron API function(s).
    *
    * @example
    * ```js
@@ -107,7 +109,7 @@ export interface ElectronServiceAPI {
    */
   resetAllMocks: (apiName?: string) => Promise<void>;
   /**
-   * Restore mocked Electron API function(s)
+   * Restore mocked Electron API function(s).
    *
    * @example
    * ```js
@@ -624,7 +626,7 @@ export interface ElectronMockInstance extends Omit<Mock, Override> {
    */
   mock: ElectronMockContext;
   /**
-   * Used internally to distinguish the electron mock from other mocks
+   * Used internally to distinguish the electron mock from other mocks.
    */
   __isElectronMock: true;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,17 @@ export interface ElectronServiceAPI {
    * @param apiName mocked api to remove
    */
   restoreAllMocks: (apiName?: string) => Promise<void>;
+  /**
+   * Checks that a given parameter is an Electron mock function. If you are using TypeScript, it will also narrow down its type.
+   *
+   * @example
+   * ```js
+   * const mockGetName = await browser.electron.mock('app', 'getName');
+   *
+   * expect(browser.electron.isMockFunction(mockGetName)).toBe(true);
+   * ```
+   */
+  isMockFunction: (fn: unknown) => fn is ElectronMockInstance;
 }
 
 /**
@@ -294,7 +305,7 @@ type Override =
   | 'withImplementation'
   | 'mock';
 
-interface ElectronMockInstance extends Omit<Mock, Override> {
+export interface ElectronMockInstance extends Omit<Mock, Override> {
   /**
    * Accepts a function that will be used as an implementation of the mock.
    *
@@ -612,6 +623,10 @@ interface ElectronMockInstance extends Omit<Mock, Override> {
    * Current context of the mock. It stores information about all invocation calls and results.
    */
   mock: ElectronMockContext;
+  /**
+   * Used internally to distinguish the electron mock from other mocks
+   */
+  __isElectronMock: true;
 }
 
 export interface ElectronMock<TArgs extends any[] = any, TReturns = any> extends ElectronMockInstance {

--- a/test/commands/isMockFunction.spec.ts
+++ b/test/commands/isMockFunction.spec.ts
@@ -1,0 +1,32 @@
+/// <reference types="../../@types/vitest" />
+import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
+
+import { createMock } from '../../src/mock.js';
+import { isMockFunction } from '../../src/commands/isMockFunction.js';
+
+describe('isMockFunction', () => {
+  beforeEach(async () => {
+    globalThis.browser = {
+      electron: {
+        execute: vi.fn(),
+      },
+    } as unknown as WebdriverIO.Browser;
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should return true for an Electron mock', async () => {
+    const mockFn = await createMock('app', 'getName');
+    expect(isMockFunction(mockFn)).toBe(true);
+  });
+
+  it('should return false for a function', () => {
+    expect(isMockFunction(() => {})).toBe(false);
+  });
+
+  it('should return false for a vitest mock', () => {
+    expect(isMockFunction(vi.fn())).toBe(false);
+  });
+});


### PR DESCRIPTION
Completing the `vitest`-like mocking API.  This will be released as 6.4.0

EDIT: Fixed "Cannot find package 'async_hooks' imported from ... `p-limit`" error, it required removing and amending vitest imports