### PR TITLE
ci: Increment the pre-release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseType:
-        description: 'Release Type'
+        description: 'Release Type. Increment the "major", "minor", "patch", or "pre-release" version.'
         required: true
         type: choice
         default: 'patch'
@@ -13,10 +13,16 @@ on:
           - patch
           - minor
           - major
+          - pre-release
       distTag:
         description: 'NPM tag (e.g. use "next" to release a test (pre-release) version)'
         required: true
         default: 'latest'
+      dryRun:
+        description: Do not touch or write anything. Show the commands.
+        required: true
+        default: false
+        type: boolean
 
 env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -52,14 +58,26 @@ jobs:
 
       - name: Pre-release
         if: ${{ inputs.distTag != 'latest' }}
-        run: pnpm run release:ci ${{inputs.releaseType}} --preRelease=${{inputs.distTag}}
+        run: |
+          INCREMENT_ARG=${{inputs.releaseType}}
+          if [ "$INCREMENT_ARG" == "pre-release" ]; then
+            unset INCREMENT_ARG
+          fi
+
+          pnpm run release:ci $INCREMENT_ARG --preRelease=${{inputs.distTag}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
         if: ${{ inputs.distTag == 'latest' }}
-        run: pnpm run release:ci ${{inputs.releaseType}} --npm.tag=${{inputs.distTag}}
+        run: |
+          if [ "${{inputs.releaseType}}" == "pre-release" ]; then
+            echo "::error ::Invalid Workflow Input: Cannot increment the "pre-release" version for a release. When the NPM Tag is set to \"latest\" the pre-release suffix (-next.0) is not added."
+            exit 1
+          fi
+
+          pnpm run release:ci ${{inputs.releaseType}} --npm.tag=${{inputs.distTag}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/development.md
+++ b/docs/development.md
@@ -101,11 +101,11 @@ To publish a pre-release, also referred to as a test release, run the Workflow w
 
 Use the **Release Type** to control which version to increment for the pre-release. The following table provides examples for publishing a pre-release from the current version `6.3.1`:
 
-| Release Type  | Pre-Release Version   |
-|---------------|-----------------------|
-| `major`       | `7.0.0-next.0`        |
-| `minor`       | `6.4.0-next.0`        |
-| `patch`       | `6.3.2-next.0`        |
-| `pre-release` | `6.3.1-next.0`        |
+| Release Type  | Pre-Release Version |
+| ------------- | ------------------- |
+| `major`       | `7.0.0-next.0`      |
+| `minor`       | `6.4.0-next.0`      |
+| `patch`       | `6.3.2-next.0`      |
+| `pre-release` | `6.3.1-next.0`      |
 
 Consecutive pre-releases can increment the `pre-release` version in the suffix. For example, if the current version is `6.3.1-next.0`, the next `pre-release` will be `6.3.1-next.1`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,18 +81,31 @@ Check the issues or [raise a new one](https://github.com/webdriverio-community/w
 
 ## Release
 
-Project maintainers can publish a release or pre-release of the npm package by manually running the [`Manual NPM Publish`](https://github.com/webdriverio-community/wdio-electron-service/actions/workflows/release.yml) GitHub Workflow. They will choose the release type to trigger a `major` , `minor`, or `patch` release following [Semantic Versioning](https://semver.org/).
+Project maintainers can publish a release or pre-release of the npm package by manually running the [`Manual NPM Publish`](https://github.com/webdriverio-community/wdio-electron-service/actions/workflows/release.yml) GitHub Workflow. They will choose the release type to trigger a `major` , `minor`, or `patch` release following [Semantic Versioning](https://semver.org/), or a pre-release. The workflow uses [`release-it`](https://github.com/release-it/release-it?tab=readme-ov-file#release-it-) to do most of the work for us.
 
-To publish a release, run the Workflow with defaults for **Branch** `main` and **NPM Tag** `latest`, and the appropriate **Release Type**. This will:
+### Publish a Release
+
+To publish a release, run the Workflow with the defaults for **Branch** `main` and **NPM Tag** `latest`, and set the appropriate **Release Type** (`major`, `minor`, or `patch`). This will:
 
 - Create a Git tag
 - Create a GitHub Release
 - Publish to npm
 
-To publish a pre-release, also referred to as a test release, run the Workflow with the **Release Type** `patch` and the **NPM Tag** `next`. This will:
+### Publish a Pre-Release
 
-- Create a Git tag with the `-next.0` suffix. Consecutive pre-releases will increment the last number.
+To publish a pre-release, also referred to as a test release, run the Workflow with the **NPM Tag** `next`. This will:
+
+- Create a Git tag with the `-next.0` suffix
 - Create a GitHub Pre-Release
 - Publish to npm
 
-The workflow uses [`release-it`](https://github.com/release-it/release-it?tab=readme-ov-file#release-it-) to do most of the work for us.
+Use the **Release Type** to control which version to increment for the pre-release. The following table provides examples for publishing a pre-release from the current version `6.3.1`:
+
+| Release Type  | Pre-Release Version   |
+|---------------|-----------------------|
+| `major`       | `7.0.0-next.0`        |
+| `minor`       | `6.4.0-next.0`        |
+| `patch`       | `6.3.2-next.0`        |
+| `pre-release` | `6.3.1-next.0`        |
+
+Consecutive pre-releases can increment the `pre-release` version in the suffix. For example, if the current version is `6.3.1-next.0`, the next `pre-release` will be `6.3.1-next.1`.


### PR DESCRIPTION
### Proposed Changes

* Add a checkbox to dry-run
* Provide a way to increment the pre-release version (e.g.: `-next.0` => `.next-1`)
* Prevent us from using the invalid release with a pre-release version
* Attempt to improve the docs
