### PR TITLE
ci: Use --dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ on:
         type: boolean
 
 env:
+  DRY_RUN_ARG: ${{ inputs.dryRun && '--dry-run' || '' }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
@@ -64,7 +65,7 @@ jobs:
             unset INCREMENT_ARG
           fi
 
-          pnpm run release:ci $INCREMENT_ARG --preRelease=${{inputs.distTag}}
+          pnpm run release:ci $INCREMENT_ARG $DRY_RUN_ARG --preRelease=${{inputs.distTag}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +78,7 @@ jobs:
             exit 1
           fi
 
-          pnpm run release:ci ${{inputs.releaseType}} --npm.tag=${{inputs.distTag}}
+          pnpm run release:ci ${{inputs.releaseType}} $DRY_RUN_ARG --npm.tag=${{inputs.distTag}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Proposed Changes

This closes issue #474.﻿

The `--dry-run` flag was not added when the `dryRun` input was set.

This PR sets the `DRY_RUN_ARG` environment variable and uses it for the pre-release and release steps.

My apologies @goosewobbler. :facepalm:

