### PR TITLE
fix: move @electron/packager to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     }
   },
   "dependencies": {
+    "@electron/packager": "^18.3.2",
     "@vitest/spy": "^1.2.0",
     "@wdio/logger": "^8.16.17",
     "compare-versions": "^6.1.0",
@@ -105,7 +106,6 @@
   },
   "devDependencies": {
     "@electron-forge/shared-types": "^7.4.0",
-    "@electron/packager": "^18.3.2",
     "@eslint/js": "^9.0.0",
     "@testing-library/webdriverio": "^3.2.1",
     "@types/debug": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@electron/packager':
+        specifier: ^18.3.2
+        version: 18.3.2
       '@vitest/spy':
         specifier: ^1.2.0
         version: 1.6.0
@@ -39,9 +42,6 @@ importers:
       '@electron-forge/shared-types':
         specifier: ^7.4.0
         version: 7.4.0
-      '@electron/packager':
-        specifier: ^18.3.2
-        version: 18.3.2
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.2.0
@@ -1004,6 +1004,7 @@ packages:
   are-we-there-yet@3.0.1:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1913,6 +1914,7 @@ packages:
   fstream@1.0.12:
     resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
     engines: {node: '>=0.6'}
+    deprecated: This package is no longer supported.
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1935,6 +1937,7 @@ packages:
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   geckodriver@4.4.0:
     resolution: {integrity: sha512-Y/Np2VkAhBkJoFAIY3pKH3rICUcR5rH9VD6EHwh0CqUIh6Opzr/NFwfcQenYfbRT/659R15/35LpA1s6h9wPPg==}
@@ -2946,6 +2949,7 @@ packages:
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   nwsapi@2.2.9:
     resolution: {integrity: sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg==}


### PR DESCRIPTION
Moves `@electron/packager` from devDependencies to dependencies so it is (recursively) installed by `npm ci`.

Otherwise this import throws a runtime error:
https://github.com/webdriverio-community/wdio-electron-service/blob/f6a5d6b0fec78b43300036faffa016b67494347d/src/application.ts#L9