### PR TITLE
fix: add entry points for N10

### DIFF
--- a/docs/common-issues-debugging.md
+++ b/docs/common-issues-debugging.md
@@ -59,6 +59,10 @@ See this [discussion](https://github.com/webdriverio-community/wdio-electron-ser
 
 ### Module not found: wdio-electron-service/preload
 
-This is a result of the preload script not being found when trying to access the electron APIs via `execute`. If you are loading extensions into Electron, you should do that at the end of the "ready" event handler. Otherwise, chromedriver will attach to the first extension's background page.
+This is a result of the preload script not being found when trying to access the electron APIs via `execute`.
+
+You should try disabling `sandbox` mode in your app as mentioned in the [accessing APIs](./electron-apis/accessing-apis.md#additional-steps-for-non-bundled-preload-scripts) documentation.
+
+Alternatively, if you are loading extensions into Electron, you should do that at the end of the "ready" event handler. Otherwise, chromedriver will attach to the first extension's background page.
 
 See this [discussion](https://github.com/webdriverio-community/wdio-electron-service/discussions/667) for more details.

--- a/packages/wdio-electron-service/main/package.json
+++ b/packages/wdio-electron-service/main/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../dist/cjs/main.js",
+  "types": "../dist/cjs/main.d.ts"
+}

--- a/packages/wdio-electron-service/package.json
+++ b/packages/wdio-electron-service/package.json
@@ -122,7 +122,9 @@
     "vitest": "^2.1.1"
   },
   "files": [
-    "dist/*"
+    "dist",
+    "main",
+    "preload"
   ],
   "release-it": {
     "hooks": {

--- a/packages/wdio-electron-service/preload/package.json
+++ b/packages/wdio-electron-service/preload/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../dist/cjs/preload.js",
+  "types": "../dist/cjs/preload.d.ts"
+}


### PR DESCRIPTION
* Adding a fallback for resolvers which do not support subpath exports: https://github.com/andrewbranch/example-subpath-exports-ts-compat/tree/main/examples/node_modules/package-json-redirects
* Updating docs to expand on possible solutions to the preload not found error