### PR TITLE
chore(ci): use deploy key to get around `main` branch restrictions during release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           ref: 'main'
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           ref: 'main'
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x


### PR DESCRIPTION
We have experienced issues ensuring our Github Actions release process can push to the main branch when protection rules are enabled, resulting in the awkward choice of being able to release and having a protected main branch.

Others have been working around this issue with a Github App, but using a deploy key seems to be a much better approach:
https://github.com/orgs/community/discussions/25305#discussioncomment-10728028