### PR TITLE
fix: add missing license and homepage metadata

### DIFF
--- a/packages/@wdio_electron-types/package.json
+++ b/packages/@wdio_electron-types/package.json
@@ -2,6 +2,8 @@
   "name": "@wdio/electron-types",
   "version": "7.0.5",
   "description": "Types for WebdriverIO Electron Service",
+  "homepage": "https://github.com/webdriverio-community/wdio-electron-service",
+  "license": "MIT",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/@wdio_electron-utils/package.json
+++ b/packages/@wdio_electron-utils/package.json
@@ -2,6 +2,8 @@
   "name": "@wdio/electron-utils",
   "version": "7.0.5",
   "description": "Utilities for WebdriverIO Electron Service",
+  "homepage": "https://github.com/webdriverio-community/wdio-electron-service",
+  "license": "MIT",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",
   "type": "module",


### PR DESCRIPTION
The lack of a license breaks license checkers