### PR TITLE
Added browserVersion to startElectron

### DIFF
--- a/packages/wdio-electron-service/src/index.ts
+++ b/packages/wdio-electron-service/src/index.ts
@@ -2,7 +2,7 @@ import { browser as wdioBrowser } from '@wdio/globals';
 
 import type { ElectronServiceOptions } from '@wdio/electron-types';
 
-import { init as initSession } from './session.js';
+import { init as initSession, InitSessionParams } from './session.js';
 import ElectronLaunchService from './launcher.js';
 import ElectronWorkerService from './service.js';
 
@@ -10,4 +10,8 @@ export const launcher = ElectronLaunchService;
 export default ElectronWorkerService;
 
 export const browser: WebdriverIO.Browser = wdioBrowser;
-export const startElectron: (opts: ElectronServiceOptions) => Promise<WebdriverIO.Browser> = initSession;
+export type StartElectronParams = InitSessionParams;
+export const startElectron: (
+  opts: ElectronServiceOptions,
+  params?: StartElectronParams,
+) => Promise<WebdriverIO.Browser> = initSession;

--- a/packages/wdio-electron-service/src/session.ts
+++ b/packages/wdio-electron-service/src/session.ts
@@ -7,10 +7,15 @@ import { CUSTOM_CAPABILITY_NAME } from './constants.js';
 import log from '@wdio/electron-utils/log';
 import type { ElectronServiceOptions } from '@wdio/electron-types';
 
-export async function init(opts: ElectronServiceOptions) {
+export interface InitSessionParams {
+  browserVersion?: string;
+}
+
+export async function init(opts: ElectronServiceOptions, params?: InitSessionParams) {
   const testRunnerOpts = opts as Options.Testrunner;
   let capabilities = {
     browserName: 'electron',
+    browserVersion: params?.browserVersion,
     [CUSTOM_CAPABILITY_NAME]: opts,
   };
 


### PR DESCRIPTION
Hello,

I'm using the wdio-electron-service for programmatically starting electron.
In my case it's not possible to auto detect the electron version, since the UI-Tests are in a separate project.

For that reason I'd like to pass the version as `browserVersion` to `startElectron`. Unfortunately that's not possible until now as it's not part of the electron capabilities.

This PR adds the `browserVersion` to `startElectron` but keeps it backward compatible. I added it to an interface so that additional parameters can be added in the future.
Please let me know if you like the approach of if you’ve a different idea how to solve this challenge.

Regards,
Jakob