### PR TITLE
Added logLevel to programmatic access

### DIFF
--- a/packages/wdio-electron-service/src/index.ts
+++ b/packages/wdio-electron-service/src/index.ts
@@ -2,7 +2,7 @@ import { browser as wdioBrowser } from '@wdio/globals';
 
 import type { ElectronServiceOptions } from '@wdio/electron-types';
 
-import { init as initSession } from './session.js';
+import { init as initSession, InitSessionParams } from './session.js';
 import ElectronLaunchService from './launcher.js';
 import ElectronWorkerService from './service.js';
 
@@ -10,4 +10,8 @@ export const launcher = ElectronLaunchService;
 export default ElectronWorkerService;
 
 export const browser: WebdriverIO.Browser = wdioBrowser;
-export const startElectron: (opts: ElectronServiceOptions) => Promise<WebdriverIO.Browser> = initSession;
+export type StartElectronParams = InitSessionParams;
+export const startElectron: (
+  opts: ElectronServiceOptions,
+  params?: StartElectronParams,
+) => Promise<WebdriverIO.Browser> = initSession;

--- a/packages/wdio-electron-service/src/session.ts
+++ b/packages/wdio-electron-service/src/session.ts
@@ -9,6 +9,7 @@ import type { ElectronServiceOptions } from '@wdio/electron-types';
 
 export interface InitSessionParams {
   browserVersion?: string;
+  logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
 }
 
 export async function init(opts: ElectronServiceOptions, params?: InitSessionParams) {
@@ -28,6 +29,7 @@ export async function init(opts: ElectronServiceOptions, params?: InitSessionPar
 
   // initialise session
   const browser = await remote({
+    logLevel: params?.logLevel,
     capabilities,
   });
 

--- a/packages/wdio-electron-service/src/session.ts
+++ b/packages/wdio-electron-service/src/session.ts
@@ -7,10 +7,15 @@ import { CUSTOM_CAPABILITY_NAME } from './constants.js';
 import log from '@wdio/electron-utils/log';
 import type { ElectronServiceOptions } from '@wdio/electron-types';
 
-export async function init(opts: ElectronServiceOptions) {
+export interface InitSessionParams {
+  browserVersion?: string;
+}
+
+export async function init(opts: ElectronServiceOptions, params?: InitSessionParams) {
   const testRunnerOpts = opts as Options.Testrunner;
   let capabilities = {
     browserName: 'electron',
+    browserVersion: params?.browserVersion,
     [CUSTOM_CAPABILITY_NAME]: opts,
   };
 


### PR DESCRIPTION
This is an extended version of https://github.com/webdriverio-community/wdio-electron-service/pull/852 that also adds the logLevel. 
I added it as PR to illustrate my comment on https://github.com/webdriverio-community/wdio-electron-service/issues/856.