### PR TITLE
fix: fix CJS import of `log` at session.ts

### DIFF
--- a/packages/@wdio_electron-utils/package.json
+++ b/packages/@wdio_electron-utils/package.json
@@ -35,6 +35,16 @@
       "./dist/cjs/log.js"
     ]
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/index.d.ts"
+      ],
+      "log": [
+        "dist/log.d.ts"
+      ]
+    }
+  },
   "engines": {
     "node": ">=18 || >=20"
   },

--- a/packages/wdio-electron-service/src/cjs/session.ts
+++ b/packages/wdio-electron-service/src/cjs/session.ts
@@ -1,6 +1,5 @@
 import { remote } from 'webdriverio';
-// TODO: Fix CJS import of `log` from '@wdio/electron-utils/log'
-// import log from '@wdio/electron-utils/log';
+import log from '@wdio/electron-utils/log';
 import type { Capabilities, Options } from '@wdio/types';
 import type { ElectronServiceCapabilities, ElectronServiceGlobalOptions } from '@wdio/electron-types';
 
@@ -15,7 +14,7 @@ export async function init(capabilities: ElectronServiceCapabilities, globalOpti
 
   await launcher.onPrepare(testRunnerOpts, capabilities);
 
-  // log.debug('Session capabilities:', capabilities);
+  log.debug('Session capabilities:', capabilities);
 
   // initialise session
   const browser = await remote({


### PR DESCRIPTION
### Description
This is update for following TODO.
Updated package.json in "@wdio/electron-utils/log" to fix this TODO.

> [TODO: Fix CJS import of `log` from '@wdio/electron-utils/log'](https://github.com/mato533/wdio-electron-service/blob/bfb4b97dbf8f823b1cbb6ba9f86cfdf276285688/packages/wdio-electron-service/src/cjs/session.ts#L2)

#### Memo
In my understand, when `CommonJS` is set `module` at `tsconfig.json`, then `moduleResolution` will be set `node10` (same as `node`) as a default.([docs](https://www.typescriptlang.org/tsconfig/#moduleResolution))
Then `exports` field of package.json(imported module side) will be ignored. (`exports` field is added [Node v12.7.0](https://nodejs.org/en/blog/release/v12.7.0).)
So this PR adds a `typesVersions` field and tells typescript to the appropriate types file.