### PR TITLE
docs: add information about appBinaryPath for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ export const config = {
 };
 ```
 
+If you manually set the path to the Electron binary, make sure you set the path correctly for MacOS 
+
+_`wdio.conf.ts`_
+
+```ts
+export const config = {
+  // ...
+  capabilities: [
+    {
+      // ...
+      'wdio:electronServiceOptions': {
+        appBinaryPath: './path/to/built/app.app/Contents/MacOS/app',
+        // ...
+      },
+    },
+  ],
+  // ...
+};
+```
+
 Alternatively, you can point the service at an unpackaged app by providing the path to the `main.js` script. Electron will need to be installed in your `node_modules`. It is recommended to bundle unpackaged apps using a bundler such as Rollup, Parcel, Webpack, etc.
 
 _`wdio.conf.ts`_

--- a/docs/configuration/service-configuration.md
+++ b/docs/configuration/service-configuration.md
@@ -51,6 +51,24 @@ Type: `string[]`
 
 The path to the Electron binary of the app for testing. In most cases the service will determine the path to your app automatically [(check here)](#automatic-detection-of-app-binary), but if this fails for some reason, e.g. your app is in a different repository from your tests, then it is recommended to set this value manually.
 
+If you manually set the path to the Electron binary, make sure you set the path correctly for MacOS 
+
+```ts
+export const config = {
+  // ...
+  capabilities: [
+    {
+      // ...
+      'wdio:electronServiceOptions': {
+        appBinaryPath: '/foo/bar/myOtherApp.app/Contents/MacOS/myOtherApp',
+        // ...
+      },
+    },
+  ],
+  // ...
+};
+```
+
 Type: `string`
 
 ### `appEntryPoint`:


### PR DESCRIPTION
Hi, thank you for your work! 

With this PR I would like to add information about `appBinaryPath` for MacOS. 

I was trying to run webdriverio for my electron application on MacOS without luck, but then I suddenly realised (while digging into the source code of wdio-electron-service) that I had configured `appBinaryPath` incorrectly. It wasn't clear to me that I had to set the path this way, so I'm suggesting this information so that it might save someone a few hours/days in the future.