### PR TITLE
fix: update type definition of the `$$` and `$`

### DIFF
--- a/e2e/test/dom.spec.ts
+++ b/e2e/test/dom.spec.ts
@@ -45,3 +45,11 @@ describe('DOM', () => {
     });
   });
 });
+
+describe('using $$', () => {
+  it('should be able to call getElements to return values', async () => {
+    const result = await $$('[data-testid="disabled-checkbox"]');
+    const chainedResult = await result.getElements();
+    expect(chainedResult.length).toBe(1);
+  });
+});

--- a/packages/@wdio_electron-types/src/index.ts
+++ b/packages/@wdio_electron-types/src/index.ts
@@ -662,11 +662,17 @@ export interface ElectronMock<TArgs extends unknown[] = unknown[], TReturns = un
   (...args: TArgs): TReturns;
 }
 
-type $ = (selector: unknown) => ChainableElementBase<WebdriverIO.Element> | WebdriverIO.Element;
-type $$ = (selector: unknown) => WebdriverIO.Element[];
+type $ = (selector: unknown) => Promise<ChainableElementBase<WebdriverIO.Element> | WebdriverIO.Element>;
+type $$ = (selector: unknown) => Promise<ChainableElementArrayBase<WebdriverIO.Element[]>>;
 type ChainableElementBase<T> = T & {
   $: $;
 };
+type ChainableElementArrayBase<T> = T & {
+  parent: Promise<WebdriverIO.Browser | WebdriverIO.Element>;
+  foundWith: string;
+  getElements: () => Promise<T>;
+};
+
 type SelectorsBase = {
   $: $;
   $$: $$;


### PR DESCRIPTION
Update type definitions of `$$` and `$` to align
 `webdriverio`.

Closes: #899