### PR TITLE
ci: workaround for CI on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Run Tests
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
+            # Workaround for linux CI
+            # https://github.com/electron/electron/issues/41066
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
             # Run tasks in serial on Ubuntu to avoid Xvfb issues
             pnpm run ci-linux
           else


### PR DESCRIPTION
This PR is a temporary fix to make CI in Linux environment running on GithubActions pass.

A fix for users running tests under Linux has been implemented in #897.