### PR TITLE
fix: add processing to parse into serializable objects when sync mock object

### DIFF
--- a/apps/builder-cjs/src/index.html
+++ b/apps/builder-cjs/src/index.html
@@ -25,6 +25,7 @@
     <div class="occurrences-2">word5 word6</div>
     <button type="button" class="make-bigger">make larger</button>
     <button type="button" class="make-smaller">make smaller</button>
+    <button type="button" class="show-dialog">show dialog</button>
     <label for="disabled-checkbox">
       Disabled checkbox
       <input id="disabled-checkbox" type="checkbox" data-testid="disabled-checkbox" disabled />
@@ -50,6 +51,11 @@
         const smallerClickCount = parseInt(document.querySelector('.smaller').innerText);
         document.querySelector('.smaller').innerText = smallerClickCount + 1;
         window.api.invoke('decrease-window-size');
+      });
+      // Add E2E scenario related to following issue
+      // https://github.com/webdriverio-community/wdio-electron-service/issues/895
+      document.querySelector('.show-dialog').addEventListener('click', () => {
+        window.api.invoke('show-open-dialog');
       });
     });
   </script>

--- a/apps/builder-cjs/src/main.ts
+++ b/apps/builder-cjs/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 const isTest = process.env.TEST === 'true';
 
 if (isTest) {
@@ -46,5 +46,16 @@ app.on('ready', () => {
   ipcMain.handle('decrease-window-size', () => {
     const bounds = mainWindow.getBounds();
     mainWindow.setBounds({ ...bounds, height: bounds.height - 10, width: bounds.width - 10 });
+  });
+
+  ipcMain.handle('show-open-dialog', async () => {
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: 'Select txt',
+      filters: [
+        { name: 'TXT', extensions: ['txt'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+    console.log(result);
   });
 });

--- a/apps/builder-cjs/src/preload.ts
+++ b/apps/builder-cjs/src/preload.ts
@@ -5,7 +5,7 @@ if (isTest) {
   require('wdio-electron-service/preload');
 }
 
-const validChannels = ['increase-window-size', 'decrease-window-size'];
+const validChannels = ['increase-window-size', 'decrease-window-size', 'show-open-dialog'];
 
 const invoke = (channel: string, ...data: unknown[]) =>
   validChannels.includes(channel) ? ipcRenderer.invoke(channel, data) : Promise.reject();

--- a/apps/builder-esm/src/index.html
+++ b/apps/builder-esm/src/index.html
@@ -25,6 +25,7 @@
     <div class="occurrences-2">word5 word6</div>
     <button type="button" class="make-bigger">make larger</button>
     <button type="button" class="make-smaller">make smaller</button>
+    <button type="button" class="show-dialog">show dialog</button>
     <label for="disabled-checkbox">
       Disabled checkbox
       <input id="disabled-checkbox" type="checkbox" data-testid="disabled-checkbox" disabled />
@@ -50,6 +51,11 @@
         const smallerClickCount = parseInt(document.querySelector('.smaller').innerText);
         document.querySelector('.smaller').innerText = smallerClickCount + 1;
         window.api.invoke('decrease-window-size');
+      });
+      // Add E2E scenario related to following issue
+      // https://github.com/webdriverio-community/wdio-electron-service/issues/895
+      document.querySelector('.show-dialog').addEventListener('click', () => {
+        window.api.invoke('show-open-dialog');
       });
     });
   </script>

--- a/apps/builder-esm/src/main.ts
+++ b/apps/builder-esm/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 const isTest = process.env.TEST === 'true';
 
 if (isTest) {
@@ -46,5 +46,16 @@ app.on('ready', () => {
   ipcMain.handle('decrease-window-size', () => {
     const bounds = mainWindow.getBounds();
     mainWindow.setBounds({ ...bounds, height: bounds.height - 10, width: bounds.width - 10 });
+  });
+
+  ipcMain.handle('show-open-dialog', async () => {
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: 'Select txt',
+      filters: [
+        { name: 'TXT', extensions: ['txt'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+    console.log(result);
   });
 });

--- a/apps/builder-esm/src/preload.cts
+++ b/apps/builder-esm/src/preload.cts
@@ -5,7 +5,7 @@ if (isTest) {
   require('wdio-electron-service/preload');
 }
 
-const validChannels = ['increase-window-size', 'decrease-window-size'];
+const validChannels = ['increase-window-size', 'decrease-window-size', 'show-open-dialog'];
 
 const invoke = (channel: string, ...data: unknown[]) =>
   validChannels.includes(channel) ? ipcRenderer.invoke(channel, data) : Promise.reject();

--- a/apps/forge-cjs/src/index.html
+++ b/apps/forge-cjs/src/index.html
@@ -25,6 +25,7 @@
     <div class="occurrences-2">word5 word6</div>
     <button type="button" class="make-bigger">make larger</button>
     <button type="button" class="make-smaller">make smaller</button>
+    <button type="button" class="show-dialog">show dialog</button>
     <label for="disabled-checkbox">
       Disabled checkbox
       <input id="disabled-checkbox" type="checkbox" data-testid="disabled-checkbox" disabled />
@@ -50,6 +51,11 @@
         const smallerClickCount = parseInt(document.querySelector('.smaller').innerText);
         document.querySelector('.smaller').innerText = smallerClickCount + 1;
         window.api.invoke('decrease-window-size');
+      });
+      // Add E2E scenario related to following issue
+      // https://github.com/webdriverio-community/wdio-electron-service/issues/895
+      document.querySelector('.show-dialog').addEventListener('click', () => {
+        window.api.invoke('show-open-dialog');
       });
     });
   </script>

--- a/apps/forge-cjs/src/main.ts
+++ b/apps/forge-cjs/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 const isTest = process.env.TEST === 'true';
 
 if (isTest) {
@@ -46,5 +46,16 @@ app.on('ready', () => {
   ipcMain.handle('decrease-window-size', () => {
     const bounds = mainWindow.getBounds();
     mainWindow.setBounds({ ...bounds, height: bounds.height - 10, width: bounds.width - 10 });
+  });
+
+  ipcMain.handle('show-open-dialog', async () => {
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: 'Select txt',
+      filters: [
+        { name: 'TXT', extensions: ['txt'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+    console.log(result);
   });
 });

--- a/apps/forge-cjs/src/preload.ts
+++ b/apps/forge-cjs/src/preload.ts
@@ -5,7 +5,7 @@ if (isTest) {
   require('wdio-electron-service/preload');
 }
 
-const validChannels = ['increase-window-size', 'decrease-window-size'];
+const validChannels = ['increase-window-size', 'decrease-window-size', 'show-open-dialog'];
 
 const invoke = (channel: string, ...data: unknown[]) =>
   validChannels.includes(channel) ? ipcRenderer.invoke(channel, data) : Promise.reject();

--- a/apps/forge-esm/src/index.html
+++ b/apps/forge-esm/src/index.html
@@ -25,6 +25,7 @@
     <div class="occurrences-2">word5 word6</div>
     <button type="button" class="make-bigger">make larger</button>
     <button type="button" class="make-smaller">make smaller</button>
+    <button type="button" class="show-dialog">show dialog</button>
     <label for="disabled-checkbox">
       Disabled checkbox
       <input id="disabled-checkbox" type="checkbox" data-testid="disabled-checkbox" disabled />
@@ -50,6 +51,11 @@
         const smallerClickCount = parseInt(document.querySelector('.smaller').innerText);
         document.querySelector('.smaller').innerText = smallerClickCount + 1;
         window.api.invoke('decrease-window-size');
+      });
+      // Add E2E scenario related to following issue
+      // https://github.com/webdriverio-community/wdio-electron-service/issues/895
+      document.querySelector('.show-dialog').addEventListener('click', () => {
+        window.api.invoke('show-open-dialog');
       });
     });
   </script>

--- a/apps/forge-esm/src/main.ts
+++ b/apps/forge-esm/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 const isTest = process.env.TEST === 'true';
 
 if (isTest) {
@@ -45,5 +45,16 @@ app.on('ready', () => {
   ipcMain.handle('decrease-window-size', () => {
     const bounds = mainWindow.getBounds();
     mainWindow.setBounds({ ...bounds, height: bounds.height - 10, width: bounds.width - 10 });
+  });
+
+  ipcMain.handle('show-open-dialog', async () => {
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: 'Select txt',
+      filters: [
+        { name: 'TXT', extensions: ['txt'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+    console.log(result);
   });
 });

--- a/apps/forge-esm/src/preload.cts
+++ b/apps/forge-esm/src/preload.cts
@@ -6,7 +6,7 @@ if (isTest) {
   require('wdio-electron-service/preload');
 }
 
-const validChannels = ['increase-window-size', 'decrease-window-size'];
+const validChannels = ['increase-window-size', 'decrease-window-size', 'show-open-dialog'];
 
 const invoke = (channel: string, ...data: unknown[]) =>
   validChannels.includes(channel) ? ipcRenderer.invoke(channel, data) : Promise.reject();

--- a/apps/no-binary-cjs/src/index.html
+++ b/apps/no-binary-cjs/src/index.html
@@ -25,6 +25,7 @@
     <div class="occurrences-2">word5 word6</div>
     <button type="button" class="make-bigger">make larger</button>
     <button type="button" class="make-smaller">make smaller</button>
+    <button type="button" class="show-dialog">show dialog</button>
     <label for="disabled-checkbox">
       Disabled checkbox
       <input id="disabled-checkbox" type="checkbox" data-testid="disabled-checkbox" disabled />
@@ -50,6 +51,11 @@
         const smallerClickCount = parseInt(document.querySelector('.smaller').innerText);
         document.querySelector('.smaller').innerText = smallerClickCount + 1;
         window.api.invoke('decrease-window-size');
+      });
+      // Add E2E scenario related to following issue
+      // https://github.com/webdriverio-community/wdio-electron-service/issues/895
+      document.querySelector('.show-dialog').addEventListener('click', () => {
+        window.api.invoke('show-open-dialog');
       });
     });
   </script>

--- a/apps/no-binary-cjs/src/main.ts
+++ b/apps/no-binary-cjs/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 const isTest = process.env.TEST === 'true';
 
 if (isTest) {
@@ -44,5 +44,16 @@ app.on('ready', () => {
   ipcMain.handle('decrease-window-size', () => {
     const bounds = mainWindow.getBounds();
     mainWindow.setBounds({ ...bounds, height: bounds.height - 10, width: bounds.width - 10 });
+  });
+
+  ipcMain.handle('show-open-dialog', async () => {
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: 'Select txt',
+      filters: [
+        { name: 'TXT', extensions: ['txt'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+    console.log(result);
   });
 });

--- a/apps/no-binary-cjs/src/preload.ts
+++ b/apps/no-binary-cjs/src/preload.ts
@@ -5,7 +5,7 @@ if (isTest) {
   require('wdio-electron-service/preload');
 }
 
-const validChannels = ['increase-window-size', 'decrease-window-size'];
+const validChannels = ['increase-window-size', 'decrease-window-size', 'show-open-dialog'];
 
 const invoke = (channel: string, ...data: unknown[]) =>
   validChannels.includes(channel) ? ipcRenderer.invoke(channel, data) : Promise.reject();

--- a/apps/no-binary-esm/src/index.html
+++ b/apps/no-binary-esm/src/index.html
@@ -25,6 +25,7 @@
     <div class="occurrences-2">word5 word6</div>
     <button type="button" class="make-bigger">make larger</button>
     <button type="button" class="make-smaller">make smaller</button>
+    <button type="button" class="show-dialog">show dialog</button>
     <label for="disabled-checkbox">
       Disabled checkbox
       <input id="disabled-checkbox" type="checkbox" data-testid="disabled-checkbox" disabled />
@@ -50,6 +51,11 @@
         const smallerClickCount = parseInt(document.querySelector('.smaller').innerText);
         document.querySelector('.smaller').innerText = smallerClickCount + 1;
         window.api.invoke('decrease-window-size');
+      });
+      // Add E2E scenario related to following issue
+      // https://github.com/webdriverio-community/wdio-electron-service/issues/895
+      document.querySelector('.show-dialog').addEventListener('click', () => {
+        window.api.invoke('show-open-dialog');
       });
     });
   </script>

--- a/apps/no-binary-esm/src/main.ts
+++ b/apps/no-binary-esm/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 const isTest = process.env.TEST === 'true';
 
 if (isTest) {
@@ -44,5 +44,16 @@ app.on('ready', () => {
   ipcMain.handle('decrease-window-size', () => {
     const bounds = mainWindow.getBounds();
     mainWindow.setBounds({ ...bounds, height: bounds.height - 10, width: bounds.width - 10 });
+  });
+
+  ipcMain.handle('show-open-dialog', async () => {
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: 'Select txt',
+      filters: [
+        { name: 'TXT', extensions: ['txt'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+    console.log(result);
   });
 });

--- a/apps/no-binary-esm/src/preload.cts
+++ b/apps/no-binary-esm/src/preload.cts
@@ -6,7 +6,7 @@ if (isTest) {
   require('wdio-electron-service/preload');
 }
 
-const validChannels = ['increase-window-size', 'decrease-window-size'];
+const validChannels = ['increase-window-size', 'decrease-window-size', 'show-open-dialog'];
 
 const invoke = (channel: string, ...data: unknown[]) =>
   validChannels.includes(channel) ? ipcRenderer.invoke(channel, data) : Promise.reject();

--- a/e2e/test/api.spec.ts
+++ b/e2e/test/api.spec.ts
@@ -788,7 +788,7 @@ describe('showOpenDialog with complex object', () => {
   // https://github.com/webdriverio-community/wdio-electron-service/issues/895
   it('should be mocked', async () => {
     const mockShowOpenDialog = await browser.electron.mock('dialog', 'showOpenDialog');
-    await browser.$('.show-dialog').click();
+    await (await $('.show-dialog')).click();
 
     expect(mockShowOpenDialog).toHaveBeenCalledTimes(1);
   });

--- a/e2e/test/api.spec.ts
+++ b/e2e/test/api.spec.ts
@@ -782,3 +782,14 @@ describe('browser.execute - workaround for TSX issue', () => {
     ).toEqual('executed inner function');
   });
 });
+
+describe('showOpenDialog with complex object', () => {
+  // Tests for the following issue
+  // https://github.com/webdriverio-community/wdio-electron-service/issues/895
+  it('should be mocked', async () => {
+    const mockShowOpenDialog = await browser.electron.mock('dialog', 'showOpenDialog');
+    await browser.$('.show-dialog').click();
+
+    expect(mockShowOpenDialog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/wdio-electron-service/src/mock.ts
+++ b/packages/wdio-electron-service/src/mock.ts
@@ -60,7 +60,7 @@ export async function createMock(apiName: string, funcName: string) {
         const mockObj = electron[apiName as keyof typeof electron][
           funcName as keyof ElectronType[ElectronInterface]
         ] as ElectronMock;
-        return mockObj.mock?.calls || [];
+        return mockObj.mock?.calls ? JSON.parse(JSON.stringify(mockObj.mock?.calls)) : [];
       },
       apiName,
       funcName,

--- a/packages/wdio-electron-service/src/service.ts
+++ b/packages/wdio-electron-service/src/service.ts
@@ -143,8 +143,31 @@ export default class ElectronWorkerService implements Services.ServiceInstance {
     const mocks = mockStore.getMocks();
     const isInternalCommand = () => Boolean((args.at(-1) as ExecuteOpts)?.internal);
 
-    const excludeCommand = ['deleteSession'];
-    if (!excludeCommand.includes(commandName) && mocks.length > 0 && !isInternalCommand()) {
+    const inputCommands = [
+      'addValue',
+      'clearValue',
+      'click',
+      'doubleClick',
+      'dragAndDrop',
+      'execute',
+      'executeAsync',
+      'moveTo',
+      'scrollIntoView',
+      'selectByAttribute',
+      'selectByIndex',
+      'selectByVisibleText',
+      'setValue',
+      'touchAction',
+      'action',
+      'actions',
+      'emulate',
+      'keys',
+      'scroll',
+      'setWindowSize',
+      'uploadFile',
+    ];
+
+    if (inputCommands.includes(commandName) && mocks.length > 0 && !isInternalCommand()) {
       await Promise.all(mocks.map(async ([_mockId, mock]) => await mock.update()));
     }
   }

--- a/packages/wdio-electron-service/src/service.ts
+++ b/packages/wdio-electron-service/src/service.ts
@@ -143,7 +143,8 @@ export default class ElectronWorkerService implements Services.ServiceInstance {
     const mocks = mockStore.getMocks();
     const isInternalCommand = () => Boolean((args.at(-1) as ExecuteOpts)?.internal);
 
-    if (commandName === 'execute' && mocks.length > 0 && !isInternalCommand()) {
+    const excludeCommand = ['deleteSession'];
+    if (!excludeCommand.includes(commandName) && mocks.length > 0 && !isInternalCommand()) {
       await Promise.all(mocks.map(async ([_mockId, mock]) => await mock.update()));
     }
   }

--- a/packages/wdio-electron-service/test/service.spec.ts
+++ b/packages/wdio-electron-service/test/service.spec.ts
@@ -170,13 +170,13 @@ describe('afterCommand', () => {
     (mockStore.getMocks as Mock).mockImplementation(() => mocks);
   });
 
-  it('should not update mocks when the command is not `execute`', async () => {
+  it.each(['deleteSession'])('should not update mocks when the command is %s', async (commandName: string) => {
     instance = new WorkerService();
     mocks = [
       ['electron.app.getName', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
       ['electron.app.getVersion', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
     ];
-    await instance.afterCommand('someCommand', [['look', 'some', 'args']]);
+    await instance.afterCommand(commandName, [['look', 'some', 'args']]);
 
     expect(mocks[0][1].update).not.toHaveBeenCalled();
     expect(mocks[1][1].update).not.toHaveBeenCalled();


### PR DESCRIPTION
### Description
Update the `mock.update` method to parse the object provided as a parameter into a serializable object when calling the mocked method.

In addition, we fixed the condition where mock.update is executed only when the `execute` command is executed, and changed it to target all commands(*) where the electron method may be called.

*) for now, i exclude the command `deleteSession`

Closes #895