### PR TITLE
chore: add the dependabot configuration for maintenance version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # For main branch
   - package-ecosystem: npm
     directory: '/'
     schedule:
@@ -22,6 +23,7 @@ updates:
       - dependency-name: 'electron-builder'
         update-types: ['version-update:semver-major', 'version-update:semver-minor', 'version-update:semver-patch']
 
+  # For maintenance branch
   - package-ecosystem: npm
     directory: '/'
     target-branch: v7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,28 @@ updates:
       # For `electron-builder`, ignore all updates (they break things)
       - dependency-name: 'electron-builder'
         update-types: ['version-update:semver-major', 'version-update:semver-minor', 'version-update:semver-patch']
+
+  - package-ecosystem: npm
+    directory: '/'
+    target-branch: v7
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - 'maintenance-version-dependencies'
+    groups:
+      production-dependencies:
+        dependency-type: 'production'
+        patterns:
+          - '*'
+      development-dependencies:
+        dependency-type: 'development'
+        patterns:
+          - '*'
+    ignore:
+      # For all packages, ignore major updates
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+      # For `electron-builder`, ignore all updates (they break things)
+      - dependency-name: 'electron-builder'
+        update-types: ['version-update:semver-major', 'version-update:semver-minor', 'version-update:semver-patch']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         type: choice
         options:
           - main
-          - v7
+          - v7 # current maintenance branch
       releaseVersion:
         description: 'The new version to create.'
         required: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,14 +142,20 @@ To create consecutive pre-releases you can select `existing` which will incremen
 | `patch`      | `6.3.2-next.0`      |
 | `existing`   | `6.3.1-next.4`      |
 
-### When update the major version
+### Major Version Maintenance Tasks
 
-The following tasks must be performed when upgrading to a major version.
+When releasing a new major version, update the maintenance branch references in the following files:
 
-1. Update the release workflow  
-   Update the part of the CI workflow(`.github/workflows/release.yml`) where `on.workflow_dispatch.inputs.branch.options` field.
-1. Update the `depeandabot` configuration for the maintenance version
-   Update the part of the configuration file(`.github/dependabot.yml`) where target-branch is not `main` (e.g. v7).
+1. Update the release workflow
+
+   - Edit `.github/workflows/release.yml`
+   - In the `on.workflow_dispatch.inputs.branch.options` field, update the maintenance branch name
+   - Example: When releasing v8, change `v6` to `v7` in the branch options
+
+2. Update the Dependabot configuration
+   - Edit `.github/dependabot.yml`
+   - Update the existing maintenance branch configuration's `target-branch`
+   - Example: When releasing v8, change `v6` to `v7` in the non-main branch configuration
 
 ## Maintenance policy
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,6 +142,15 @@ To create consecutive pre-releases you can select `existing` which will incremen
 | `patch`      | `6.3.2-next.0`      |
 | `existing`   | `6.3.1-next.4`      |
 
+### When update the major version
+
+The following tasks must be performed when upgrading to a major version.
+
+1. Update the release workflow  
+   Update the part of the CI workflow(`.github/workflows/release.yml`) where `on.workflow_dispatch.inputs.branch.options` field.
+1. Update the `depeandabot` configuration for the maintenance version
+   Update the part of the configuration file(`.github/dependabot.yml`) where target-branch is not `main` (e.g. v7).
+
 ## Maintenance policy
 
 Starting from v8 the team intends to backport all features that would be still backwards compatible with older (maintained) versions. With a new major version update (e.g. v8) we continue to maintain the previous version (e.g. v7) and deprecate the previously maintained version (e.g. v6 and lower).


### PR DESCRIPTION
This PR include following changes.
-  the dependabot configuration for maintenance version (currently v7)
-  the document about task list when major version is updated