### PR TITLE
feat: support object inspection at debug log

### DIFF
--- a/packages/@wdio_electron-utils/src/log.ts
+++ b/packages/@wdio_electron-utils/src/log.ts
@@ -7,7 +7,14 @@ const l = logger('electron-service');
 const log: Logger = {
   ...l,
   debug: (...args) => {
-    d(args);
+    if (typeof args.at(-1) === 'object') {
+      if (args.length > 1) {
+        d(args.slice(0, -1));
+      }
+      d('%O', args.at(-1));
+    } else {
+      d(args);
+    }
     l.debug(...args);
   },
 };


### PR DESCRIPTION
### Purpose
I want to change the hierarchy of objects in the debug log that can be analyzed using [‘DEBUG_DEPTH’](https://github.com/debug-js/debug?tab=readme-ov-file#environment-variables).

### Description
For this purpose, if the last element of the argument passed to debug is of type Object, we want to change it so that it is output with [the appropriate formatting](https://github.com/debug-js/debug?tab=readme-ov-file#formatters).

### Result

Run with `DEBUG_DEPTH` set in the environment variable.

```bash
pnpm exec cross-env DEBUG_DEPTH=3 pnpm run exec:main
```

The third level also outputs values (the output is not like Array, Object, etc...).

```bash
  wdio-electron-service [ 'setting capability' ] +1s
  wdio-electron-service {
  wdio-electron-service   browserName: 'chrome',
  wdio-electron-service   'wdio:electronServiceOptions': {
  wdio-electron-service     appBinaryPath: '/path/to/wdio-electron-service/apps/builder-esm/dist/mac-arm64/example-builder-esm.app/Contents/MacOS/example-builder-esm',
  wdio-electron-service     appArgs: [ 'browser=A' ] // Not Object
  wdio-electron-service   },
  wdio-electron-service   'goog:chromeOptions': {
  wdio-electron-service     binary: '/path/to/wdio-electron-service/apps/builder-esm/dist/mac-arm64/example-builder-esm.app/Contents/MacOS/example-builder-esm',
  wdio-electron-service     windowTypes: [ 'app', 'webview' ],  // Not Object
  wdio-electron-service     args: [ 'browser=A' ]  // Not Object
  wdio-electron-service   },
  wdio-electron-service   'wdio:enforceWebDriverClassic': true,
  wdio-electron-service   browserVersion: '132.0.6834.159'
  wdio-electron-service } +0ms
```
