### PR TITLE
chore: add  `--access=public` to publish

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -9,7 +9,7 @@ shell.cp(['LICENSE'], 'packages/@wdio_electron-utils');
 shell.cp(['LICENSE'], 'packages/@wdio_electron-types');
 
 // --no-git-checks is used to skip the git checks - due to getting erroneous ERR_PNPM_GIT_UNCLEAN errors
-const publishCommand = `pnpm publish -r --no-git-checks ${options.join(' ')}`;
+const publishCommand = `pnpm publish -r --access=public --no-git-checks ${options.join(' ')}`;
 
 console.log(`Publishing wdio-electron-service...`, publishCommand);
 

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -9,7 +9,7 @@ shell.cp(['LICENSE'], 'packages/@wdio_electron-utils');
 shell.cp(['LICENSE'], 'packages/@wdio_electron-types');
 
 // --no-git-checks is used to skip the git checks - due to getting erroneous ERR_PNPM_GIT_UNCLEAN errors
-const publishCommand = `pnpm publish -r --access=public --no-git-checks ${options.join(' ')}`;
+const publishCommand = `pnpm publish -r --access public --no-git-checks ${options.join(' ')}`;
 
 console.log(`Publishing wdio-electron-service...`, publishCommand);
 


### PR DESCRIPTION
We need to be able to publish `@wdio/electron-bundler`:

https://github.com/webdriverio-community/wdio-electron-service/actions/runs/13275522535/job/37064292050#step:10:54