### PR TITLE
chore: remove version from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "wdio-electron-service-monorepo",
   "private": true,
-  "version": "7.4.0-next.2",
   "type": "module",
   "engines": {
     "node": ">=18 || >=20"


### PR DESCRIPTION
Remove the field of `version` from root `package.json` which is not maintained.