### PR TITLE
chore: update rollup.config.js to fix CJS issue for logger

### DIFF
--- a/packages/@wdio_electron-bundler/src/utils.ts
+++ b/packages/@wdio_electron-bundler/src/utils.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { basename, dirname, join, posix, relative, sep } from 'node:path';
+import { basename, dirname, join, posix, relative } from 'node:path';
 import { readPackageUpSync, type NormalizedReadResult } from 'read-package-up';
 
 import debug from './log';

--- a/packages/@wdio_electron-bundler/test/plugins.spec.ts
+++ b/packages/@wdio_electron-bundler/test/plugins.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type {
   NormalizedOutputOptions,
   PluginContext,
@@ -8,7 +7,14 @@ import type {
   TransformPluginContext,
   RenderedChunk,
 } from 'rollup';
-import { codeReplacePlugin, emitPackageJsonPlugin, injectDependencyPlugin, warnToErrorPlugin } from '../src/plugins';
+import {
+  codeReplacePlugin,
+  emitPackageJsonPlugin,
+  injectDependencyPlugin,
+  warnToErrorPlugin,
+  MODULE_TYPE,
+  type SourceCodeType,
+} from '../src/plugins';
 
 type Transform = (this: TransformPluginContext, code: string, id: string) => Promise<void>;
 type RenderChunk = (this: PluginContext, code: string, chunk: RenderedChunk) => Promise<void>;
@@ -35,10 +41,9 @@ describe('emitPackageJsonPlugin', () => {
   } as unknown as PluginContext;
 
   it.each([
-    ['esm', 'module'],
-    ['cjs', 'commonjs'],
+    [MODULE_TYPE.ESM, 'module'],
+    [MODULE_TYPE.CJS, 'commonjs'],
   ])('should emit package.json with correct type for %s format', async (format, moduleType) => {
-    // @ts-expect-error
     const plugin = emitPackageJsonPlugin('test-pkg', format);
 
     await (plugin.generateBundle! as unknown as GenerateBundle).call(context, {
@@ -54,8 +59,9 @@ describe('emitPackageJsonPlugin', () => {
   });
 
   it('should throw an error for invalid package type', async () => {
-    // @ts-expect-error
-    expect(() => emitPackageJsonPlugin('test-pkg', 'invalid')).toThrowError('Invalid type is specified');
+    expect(() => emitPackageJsonPlugin('test-pkg', 'invalid' as SourceCodeType)).toThrowError(
+      'Invalid type is specified',
+    );
   });
 });
 
@@ -135,9 +141,9 @@ describe('codeReplacePlugin', () => {
   const context = {
     info: vi.fn(),
     warn: vi.fn(),
-  } as unknown as TransformPluginContext;
+  } as unknown as PluginContext;
 
-  it('should successfully replace the code', async () => {
+  it('should successfully replace multiple code patterns', async () => {
     const plugin = codeReplacePlugin([
       {
         id: 'src/log.ts',
@@ -150,43 +156,72 @@ describe('codeReplacePlugin', () => {
         replaceValue: "import sample from 'sample-lib';",
       },
     ]);
+
     const result = await (plugin.renderChunk as unknown as RenderChunk).call(
       context,
       ["const test = require('test-lib');", "const sample = require('sample-lib');"].join('\n'),
       { facadeModuleId: '/path/to/src/log.ts' } as RenderedChunk,
     );
+
     expect(result).toStrictEqual({
       code: ["import test from 'test-lib';", "import sample from 'sample-lib';"].join('\n'),
       map: null,
     });
+    expect(context.info).toHaveBeenCalledTimes(2);
+    expect(context.warn).not.toHaveBeenCalled();
   });
-  it('should call warn when failed to replace the code', async () => {
+
+  it('should warn and return null when pattern is not found', async () => {
     const plugin = codeReplacePlugin({
       id: 'src/log.ts',
       searchValue: "const test = require('test-lib');",
       replaceValue: "import test from 'test-lib';",
     });
+
     const result = await (plugin.renderChunk as unknown as RenderChunk).call(
       context,
-      ["const xxx = require('test-lib');", "const yyy = require('sample-lib');"].join('\n'),
+      "const differentPattern = require('test-lib');",
       { facadeModuleId: '/path/to/src/log.ts' } as RenderedChunk,
     );
-    expect(context.warn).toHaveBeenCalledTimes(1);
+
     expect(result).toBeNull();
+    expect(context.warn).toHaveBeenCalledWith('No replacements made for pattern in src/log.ts');
+    expect(context.info).not.toHaveBeenCalled();
   });
-  it('should return null when not match id and configuration of plugin', async () => {
+
+  it('should return null when facadeModuleId does not match target', async () => {
     const plugin = codeReplacePlugin({
       id: 'src/log.ts',
       searchValue: "const test = require('test-lib');",
       replaceValue: "import test from 'test-lib';",
     });
+
     const result = await (plugin.renderChunk as unknown as RenderChunk).call(
       context,
-      ["const xxx = require('test-lib');", "const yyy = require('sample-lib');"].join('\n'),
-      { facadeModuleId: '/path/to/src/index.ts' } as RenderedChunk,
+      "const test = require('test-lib');",
+      { facadeModuleId: '/path/to/src/different.ts' } as RenderedChunk,
     );
-    expect(context.warn).toHaveBeenCalledTimes(0);
-    expect(context.info).toHaveBeenCalledTimes(0);
+
     expect(result).toBeNull();
+    expect(context.warn).not.toHaveBeenCalled();
+    expect(context.info).not.toHaveBeenCalled();
+  });
+
+  it('should return null when facadeModuleId is missing', async () => {
+    const plugin = codeReplacePlugin({
+      id: 'src/log.ts',
+      searchValue: "const test = require('test-lib');",
+      replaceValue: "import test from 'test-lib';",
+    });
+
+    const result = await (plugin.renderChunk as unknown as RenderChunk).call(
+      context,
+      "const test = require('test-lib');",
+      { facadeModuleId: '' } as RenderedChunk,
+    );
+
+    expect(result).toBeNull();
+    expect(context.warn).not.toHaveBeenCalled();
+    expect(context.info).not.toHaveBeenCalled();
   });
 });

--- a/packages/@wdio_electron-bundler/test/utils.spec.ts
+++ b/packages/@wdio_electron-bundler/test/utils.spec.ts
@@ -147,10 +147,11 @@ describe('getInputConfig', () => {
 
   it('should resolve entry points from nested import/require fields', () => {
     vi.mocked(existsSync).mockImplementation((path: PathLike) => {
+      const normalizedPath = path.toString().replace(/\\/g, '/');
       return (
-        path.toString().endsWith('src/nested.ts') ||
-        path.toString().endsWith('src/deep.ts') ||
-        path.toString().endsWith('src/index.ts')
+        normalizedPath.endsWith('src/nested.ts') ||
+        normalizedPath.endsWith('src/deep.ts') ||
+        normalizedPath.endsWith('src/index.ts')
       );
     });
 

--- a/packages/@wdio_electron-bundler/test/utils.spec.ts
+++ b/packages/@wdio_electron-bundler/test/utils.spec.ts
@@ -15,14 +15,15 @@ describe('getInputConfig', () => {
 
   it('should resolve entry points from exports field', () => {
     vi.mocked(existsSync).mockImplementation((path: PathLike) => {
+      const normalizedPath = path.toString().replace(/\\/g, '/');
       return (
-        path.toString().endsWith('src/index.ts') ||
-        path.toString().endsWith('src/mod1.ts') ||
-        path.toString().endsWith('src/mod2/index.ts') ||
-        path.toString().endsWith('src/mod3.mts') ||
-        path.toString().endsWith('src/mod4/index.mts') ||
-        path.toString().endsWith('src/mod5/api.cts') ||
-        path.toString().endsWith('src/mod6/api/index.cts')
+        normalizedPath.endsWith('src/index.ts') ||
+        normalizedPath.endsWith('src/mod1.ts') ||
+        normalizedPath.endsWith('src/mod2/index.ts') ||
+        normalizedPath.endsWith('src/mod3.mts') ||
+        normalizedPath.endsWith('src/mod4/index.mts') ||
+        normalizedPath.endsWith('src/mod5/api.cts') ||
+        normalizedPath.endsWith('src/mod6/api/index.cts')
       );
     });
 
@@ -184,7 +185,8 @@ describe('getInputConfig', () => {
 
   it('should handle entry points with only import field', () => {
     vi.mocked(existsSync).mockImplementation((path: PathLike) => {
-      return path.toString().endsWith('src/importOnly.ts') || path.toString().endsWith('src/index.ts');
+      const normalizedPath = path.toString().replace(/\\/g, '/');
+      return normalizedPath.endsWith('src/importOnly.ts') || normalizedPath.endsWith('src/index.ts');
     });
 
     const exports = {
@@ -214,7 +216,8 @@ describe('getInputConfig', () => {
 
   it('should handle entry points with only require field', () => {
     vi.mocked(existsSync).mockImplementation((path: PathLike) => {
-      return path.toString().endsWith('src/requireOnly.ts') || path.toString().endsWith('src/index.ts');
+      const normalizedPath = path.toString().replace(/\\/g, '/');
+      return normalizedPath.endsWith('src/requireOnly.ts') || normalizedPath.endsWith('src/index.ts');
     });
 
     const exports = {

--- a/packages/@wdio_electron-utils/rollup.config.ts
+++ b/packages/@wdio_electron-utils/rollup.config.ts
@@ -4,6 +4,7 @@ import {
   emitPackageJsonPlugin,
   readPackageJson,
   warnToErrorPlugin,
+  codeReplacePlugin,
 } from '@wdio/electron-bundler';
 
 import type { RollupOptions } from 'rollup';
@@ -48,6 +49,13 @@ const configCjs: RollupOptions = {
     }),
     nodeExternals(),
     warnToErrorPlugin(),
+    // @wdio/logger is only support ESM, so we have to use `import` even if CJS format.
+    // https://github.com/webdriverio-community/wdio-electron-service/issues/944
+    codeReplacePlugin({
+      id: 'src/log.ts',
+      searchValue: "var logger = require('@wdio/logger');",
+      replaceValue: "import logger from '@wdio/logger';",
+    }),
   ],
   strictDeprecations: true,
 };

--- a/packages/@wdio_electron-utils/rollup.config.ts
+++ b/packages/@wdio_electron-utils/rollup.config.ts
@@ -49,8 +49,12 @@ const configCjs: RollupOptions = {
     }),
     nodeExternals(),
     warnToErrorPlugin(),
-    // @wdio/logger is only support ESM, so we have to use `import` even if CJS format.
-    // https://github.com/webdriverio-community/wdio-electron-service/issues/944
+    /**
+     * Plugin to handle ESM/CJS compatibility issues with @wdio/logger.
+     * The logger only supports ESM imports due to its dependency on chalk v5.
+     *
+     * @see https://github.com/webdriverio-community/wdio-electron-service/issues/944
+     */
     codeReplacePlugin({
       id: 'src/log.ts',
       searchValue: "var logger = require('@wdio/logger');",


### PR DESCRIPTION
 Fix CJS issue for logger.
 
 The `@wdio/logger` is not support the CJS.
 So this PR is add the plugin to replace to import instead of require.