### PR TITLE
ci: use `lts` and `lts-next` tags for NPM when releasing from a non-main branch

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -61,7 +61,9 @@ jobs:
         run: pnpm turbo-version -b ${{ inputs.preReleaseVersion }}
       - name: Publish to NPM
         shell: bash
-        run: pnpx tsx scripts/publish.ts --tag next ${{ inputs.dryRun && '--dry-run' || '' }}
+        run: |
+          test "${RELEASE_BRANCH}" == "main" && TAG="next" || TAG="lts-next"
+          pnpx tsx scripts/publish.ts --tag $TAG ${{ inputs.dryRun && '--dry-run' || '' }}
       - name: Log git changes
         if: ${{ inputs.dryRun }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           RELEASE_BRANCH: ${{ inputs.branch }}
         run: |
-          test "${RELEASE_BRANCH}" == "main" && TAG="latest" || TAG="${RELEASE_BRANCH}"
+          test "${RELEASE_BRANCH}" == "main" && TAG="latest" || TAG="lts"
           pnpx tsx scripts/publish.ts --tag ${TAG} ${{ inputs.dryRun && '--dry-run' || '' }}
       - name: Log git changes
         if: ${{ inputs.dryRun }}


### PR DESCRIPTION
Updating the release and pre-release tag handling for NPM so that the following logic applies:

- Release main: npm tag is `latest`
- Pre-release main: npm tag is `next`
- Release non-main: npm tag is `lts`
- Pre-release non-main: npm tag is `lts-next`

This enables us to have separate tags for the LTS / maintenance releases.  We are assuming that releases and pre-releases will only ever happen from either `main` or the preconfigured LTS / maintenance branch (currently v7).