### PR TITLE
test: add missing unit test

### DIFF
--- a/packages/@wdio_electron-bundler/test/index.spec.ts
+++ b/packages/@wdio_electron-bundler/test/index.spec.ts
@@ -4,58 +4,60 @@ import { readPackageJson, typescript } from '../src/index';
 import { getFixturePackagePath } from './utils';
 import typescriptPlugin from '@rollup/plugin-typescript';
 
-describe('readPackageJson', () => {
-  it('should return input configuration and output directories', () => {
-    const fixture = getFixturePackagePath('esm', 'build-test-esm');
-    const cwd = dirname(fixture);
-    const result = readPackageJson(cwd);
+describe('Bundler Utilities', () => {
+  describe('readPackageJson()', () => {
+    it('should return input configuration and output directories', () => {
+      const fixture = getFixturePackagePath('esm', 'build-test-esm');
+      const cwd = dirname(fixture);
+      const result = readPackageJson(cwd);
 
-    expect(result.input).toStrictEqual({ index: 'src/index.ts' });
-    expect(result.pkgName).toBe('fixture-esm_builder-dependency-cjs-config');
-    expect(result.outDir).toStrictEqual({ esm: './dist/es', cjs: './dist/cjs' });
-  });
-});
-
-describe('typescript', () => {
-  vi.mock('@rollup/plugin-typescript', () => ({
-    default: vi.fn(() => 'mocked-plugin'),
-  }));
-
-  it('should apply default TypeScript configuration', () => {
-    const plugin = typescript({
-      compilerOptions: {
-        outDir: 'path/to/out',
-      },
-    });
-    expect(plugin).toBe('mocked-plugin');
-
-    expect(typescriptPlugin).toHaveBeenCalledWith({
-      compilerOptions: {
-        outDir: 'path/to/out',
-        declaration: true,
-        declarationMap: true,
-      },
-      exclude: ['rollup.config.ts'],
+      expect(result.input).toStrictEqual({ index: 'src/index.ts' });
+      expect(result.pkgName).toBe('fixture-esm_builder-dependency-cjs-config');
+      expect(result.outDir).toStrictEqual({ esm: './dist/es', cjs: './dist/cjs' });
     });
   });
 
-  it.each([
-    ['array of files', ['test.ts']],
-    ['single file', 'test.ts'],
-  ])('should merge exclude patterns when given %s', (_type, exclude) => {
-    typescript({
-      compilerOptions: {
-        outDir: 'path/to/out',
-      },
-      exclude,
+  describe('typescript()', () => {
+    vi.mock('@rollup/plugin-typescript', () => ({
+      default: vi.fn(() => 'mocked-plugin'),
+    }));
+
+    it('should apply default TypeScript configuration', () => {
+      const plugin = typescript({
+        compilerOptions: {
+          outDir: 'path/to/out',
+        },
+      });
+      expect(plugin).toBe('mocked-plugin');
+
+      expect(typescriptPlugin).toHaveBeenCalledWith({
+        compilerOptions: {
+          outDir: 'path/to/out',
+          declaration: true,
+          declarationMap: true,
+        },
+        exclude: ['rollup.config.ts'],
+      });
     });
-    expect(typescriptPlugin).toHaveBeenCalledWith({
-      compilerOptions: {
-        outDir: 'path/to/out',
-        declaration: true,
-        declarationMap: true,
-      },
-      exclude: ['rollup.config.ts', 'test.ts'],
+
+    it.each([
+      ['array of files', ['test.ts']],
+      ['single file', 'test.ts'],
+    ])('should merge exclude patterns when given %s', (_type, exclude) => {
+      typescript({
+        compilerOptions: {
+          outDir: 'path/to/out',
+        },
+        exclude,
+      });
+      expect(typescriptPlugin).toHaveBeenCalledWith({
+        compilerOptions: {
+          outDir: 'path/to/out',
+          declaration: true,
+          declarationMap: true,
+        },
+        exclude: ['rollup.config.ts', 'test.ts'],
+      });
     });
   });
 });

--- a/packages/@wdio_electron-bundler/test/plugins.spec.ts
+++ b/packages/@wdio_electron-bundler/test/plugins.spec.ts
@@ -34,194 +34,196 @@ vi.mock('../src/utils', async () => {
   };
 });
 
-describe('emitPackageJsonPlugin', () => {
-  const context = {
-    debug: vi.fn(),
-    emitFile: vi.fn(),
-  } as unknown as PluginContext;
+describe('Rollup Plugins', () => {
+  describe('emitPackageJsonPlugin()', () => {
+    const context = {
+      debug: vi.fn(),
+      emitFile: vi.fn(),
+    } as unknown as PluginContext;
 
-  it.each([
-    [MODULE_TYPE.ESM, 'module'],
-    [MODULE_TYPE.CJS, 'commonjs'],
-  ])('should emit package.json with correct type for %s format', async (format, moduleType) => {
-    const plugin = emitPackageJsonPlugin('test-pkg', format);
+    it.each([
+      [MODULE_TYPE.ESM, 'module'],
+      [MODULE_TYPE.CJS, 'commonjs'],
+    ])('should emit package.json with correct type for %s format', async (format, moduleType) => {
+      const plugin = emitPackageJsonPlugin('test-pkg', format);
 
-    await (plugin.generateBundle! as unknown as GenerateBundle).call(context, {
-      dir: 'dist',
-    } as NormalizedOutputOptions);
+      await (plugin.generateBundle! as unknown as GenerateBundle).call(context, {
+        dir: 'dist',
+      } as NormalizedOutputOptions);
 
-    expect(context.emitFile).toHaveBeenCalledTimes(1);
-    expect(context.emitFile).toHaveBeenCalledWith({
-      type: 'asset',
-      fileName: 'package.json',
-      source: `{\n  "name": "test-pkg-${format}",\n  "type": "${moduleType}",\n  "private": true\n}`,
+      expect(context.emitFile).toHaveBeenCalledTimes(1);
+      expect(context.emitFile).toHaveBeenCalledWith({
+        type: 'asset',
+        fileName: 'package.json',
+        source: `{\n  "name": "test-pkg-${format}",\n  "type": "${moduleType}",\n  "private": true\n}`,
+      });
+    });
+
+    it('should throw an error for invalid package type', async () => {
+      expect(() => emitPackageJsonPlugin('test-pkg', 'invalid' as SourceCodeType)).toThrowError(
+        'Invalid type is specified',
+      );
     });
   });
 
-  it('should throw an error for invalid package type', async () => {
-    expect(() => emitPackageJsonPlugin('test-pkg', 'invalid' as SourceCodeType)).toThrowError(
-      'Invalid type is specified',
-    );
+  describe('warnToErrorPlugin()', () => {
+    const context = {
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as PluginContext;
+
+    it('should escalate warnings to errors', async () => {
+      const plugin = warnToErrorPlugin();
+      (plugin.onLog! as unknown as OnLog).call(context, 'warn', { message: 'message' });
+      expect(context.warn).toHaveBeenCalledTimes(1);
+      expect(context.error).toHaveBeenCalledTimes(1);
+    });
   });
-});
 
-describe('warnToErrorPlugin', () => {
-  const context = {
-    warn: vi.fn(),
-    error: vi.fn(),
-  } as unknown as PluginContext;
+  describe('injectDependencyPlugin()', () => {
+    const context = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as TransformPluginContext;
 
-  it('should escalate warnings to errors', async () => {
-    const plugin = warnToErrorPlugin();
-    (plugin.onLog! as unknown as OnLog).call(context, 'warn', { message: 'message' });
-    expect(context.warn).toHaveBeenCalledTimes(1);
-    expect(context.error).toHaveBeenCalledTimes(1);
-  });
-});
+    it('should successfully inject dependencies', async () => {
+      const plugin = injectDependencyPlugin([
+        {
+          packageName: '@vitest/spy',
+          targetFile: 'src/mock.ts',
+          bundleRegExp: /export/,
+          importName: 'spy',
+          bundleReplace: (importName: string) => `const ${importName} =`,
+        },
+        {
+          packageName: 'fast-copy',
+          targetFile: 'src/service.ts',
+          bundleRegExp: /export.*$/m,
+          importName: '{ default: copy }',
+          bundleReplace: (importName: string) => `const ${importName} = { default: index };`,
+        },
+      ]);
 
-describe('injectDependencyPlugin', () => {
-  const context = {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  } as unknown as TransformPluginContext;
+      const result1 = await (plugin.transform as unknown as Transform).call(
+        context,
+        `const a = 1`,
+        '/path/to/src/mock.ts',
+      );
+      expect(result1).toStrictEqual({ code: 'const a = 1\nconst spy = 1', map: null });
 
-  it('should successfully inject dependencies', async () => {
-    const plugin = injectDependencyPlugin([
-      {
+      const result2 = await (plugin.transform as unknown as Transform).call(
+        context,
+        `const a = 1`,
+        '/path/to/src/src/service.ts',
+      );
+      expect(result2).toStrictEqual({ code: 'const a = 1\nconst { default: copy } = 2', map: null });
+    });
+
+    it('should return null when input id is not injection target', async () => {
+      const plugin = injectDependencyPlugin({
         packageName: '@vitest/spy',
         targetFile: 'src/mock.ts',
         bundleRegExp: /export/,
         importName: 'spy',
         bundleReplace: (importName: string) => `const ${importName} =`,
-      },
-      {
-        packageName: 'fast-copy',
-        targetFile: 'src/service.ts',
-        bundleRegExp: /export.*$/m,
-        importName: '{ default: copy }',
-        bundleReplace: (importName: string) => `const ${importName} = { default: index };`,
-      },
-    ]);
+      });
 
-    const result1 = await (plugin.transform as unknown as Transform).call(
-      context,
-      `const a = 1`,
-      '/path/to/src/mock.ts',
-    );
-    expect(result1).toStrictEqual({ code: 'const a = 1\nconst spy = 1', map: null });
-
-    const result2 = await (plugin.transform as unknown as Transform).call(
-      context,
-      `const a = 1`,
-      '/path/to/src/src/service.ts',
-    );
-    expect(result2).toStrictEqual({ code: 'const a = 1\nconst { default: copy } = 2', map: null });
+      const result1 = await (plugin.transform as unknown as Transform).call(
+        context,
+        `const a = 1`,
+        '/path/to/src/notfound.ts',
+      );
+      expect(result1).toBeNull();
+    });
   });
 
-  it('should return null when input id is not injection target', async () => {
-    const plugin = injectDependencyPlugin({
-      packageName: '@vitest/spy',
-      targetFile: 'src/mock.ts',
-      bundleRegExp: /export/,
-      importName: 'spy',
-      bundleReplace: (importName: string) => `const ${importName} =`,
+  describe('codeReplacePlugin()', () => {
+    const context = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as PluginContext;
+
+    it('should successfully replace multiple code patterns', async () => {
+      const plugin = codeReplacePlugin([
+        {
+          id: 'src/log.ts',
+          searchValue: "const test = require('test-lib');",
+          replaceValue: "import test from 'test-lib';",
+        },
+        {
+          id: 'src/log.ts',
+          searchValue: "const sample = require('sample-lib');",
+          replaceValue: "import sample from 'sample-lib';",
+        },
+      ]);
+
+      const result = await (plugin.renderChunk as unknown as RenderChunk).call(
+        context,
+        ["const test = require('test-lib');", "const sample = require('sample-lib');"].join('\n'),
+        { facadeModuleId: '/path/to/src/log.ts' } as RenderedChunk,
+      );
+
+      expect(result).toStrictEqual({
+        code: ["import test from 'test-lib';", "import sample from 'sample-lib';"].join('\n'),
+        map: null,
+      });
+      expect(context.info).toHaveBeenCalledTimes(2);
+      expect(context.warn).not.toHaveBeenCalled();
     });
 
-    const result1 = await (plugin.transform as unknown as Transform).call(
-      context,
-      `const a = 1`,
-      '/path/to/src/notfound.ts',
-    );
-    expect(result1).toBeNull();
-  });
-});
-
-describe('codeReplacePlugin', () => {
-  const context = {
-    info: vi.fn(),
-    warn: vi.fn(),
-  } as unknown as PluginContext;
-
-  it('should successfully replace multiple code patterns', async () => {
-    const plugin = codeReplacePlugin([
-      {
+    it('should warn and return null when pattern is not found', async () => {
+      const plugin = codeReplacePlugin({
         id: 'src/log.ts',
         searchValue: "const test = require('test-lib');",
         replaceValue: "import test from 'test-lib';",
-      },
-      {
+      });
+
+      const result = await (plugin.renderChunk as unknown as RenderChunk).call(
+        context,
+        "const differentPattern = require('test-lib');",
+        { facadeModuleId: '/path/to/src/log.ts' } as RenderedChunk,
+      );
+
+      expect(result).toBeNull();
+      expect(context.warn).toHaveBeenCalledWith('No replacements made for pattern in src/log.ts');
+      expect(context.info).not.toHaveBeenCalled();
+    });
+
+    it('should return null when facadeModuleId does not match target', async () => {
+      const plugin = codeReplacePlugin({
         id: 'src/log.ts',
-        searchValue: "const sample = require('sample-lib');",
-        replaceValue: "import sample from 'sample-lib';",
-      },
-    ]);
+        searchValue: "const test = require('test-lib');",
+        replaceValue: "import test from 'test-lib';",
+      });
 
-    const result = await (plugin.renderChunk as unknown as RenderChunk).call(
-      context,
-      ["const test = require('test-lib');", "const sample = require('sample-lib');"].join('\n'),
-      { facadeModuleId: '/path/to/src/log.ts' } as RenderedChunk,
-    );
+      const result = await (plugin.renderChunk as unknown as RenderChunk).call(
+        context,
+        "const test = require('test-lib');",
+        { facadeModuleId: '/path/to/src/different.ts' } as RenderedChunk,
+      );
 
-    expect(result).toStrictEqual({
-      code: ["import test from 'test-lib';", "import sample from 'sample-lib';"].join('\n'),
-      map: null,
-    });
-    expect(context.info).toHaveBeenCalledTimes(2);
-    expect(context.warn).not.toHaveBeenCalled();
-  });
-
-  it('should warn and return null when pattern is not found', async () => {
-    const plugin = codeReplacePlugin({
-      id: 'src/log.ts',
-      searchValue: "const test = require('test-lib');",
-      replaceValue: "import test from 'test-lib';",
+      expect(result).toBeNull();
+      expect(context.warn).not.toHaveBeenCalled();
+      expect(context.info).not.toHaveBeenCalled();
     });
 
-    const result = await (plugin.renderChunk as unknown as RenderChunk).call(
-      context,
-      "const differentPattern = require('test-lib');",
-      { facadeModuleId: '/path/to/src/log.ts' } as RenderedChunk,
-    );
+    it('should return null when facadeModuleId is missing', async () => {
+      const plugin = codeReplacePlugin({
+        id: 'src/log.ts',
+        searchValue: "const test = require('test-lib');",
+        replaceValue: "import test from 'test-lib';",
+      });
 
-    expect(result).toBeNull();
-    expect(context.warn).toHaveBeenCalledWith('No replacements made for pattern in src/log.ts');
-    expect(context.info).not.toHaveBeenCalled();
-  });
+      const result = await (plugin.renderChunk as unknown as RenderChunk).call(
+        context,
+        "const test = require('test-lib');",
+        { facadeModuleId: '' } as RenderedChunk,
+      );
 
-  it('should return null when facadeModuleId does not match target', async () => {
-    const plugin = codeReplacePlugin({
-      id: 'src/log.ts',
-      searchValue: "const test = require('test-lib');",
-      replaceValue: "import test from 'test-lib';",
+      expect(result).toBeNull();
+      expect(context.warn).not.toHaveBeenCalled();
+      expect(context.info).not.toHaveBeenCalled();
     });
-
-    const result = await (plugin.renderChunk as unknown as RenderChunk).call(
-      context,
-      "const test = require('test-lib');",
-      { facadeModuleId: '/path/to/src/different.ts' } as RenderedChunk,
-    );
-
-    expect(result).toBeNull();
-    expect(context.warn).not.toHaveBeenCalled();
-    expect(context.info).not.toHaveBeenCalled();
-  });
-
-  it('should return null when facadeModuleId is missing', async () => {
-    const plugin = codeReplacePlugin({
-      id: 'src/log.ts',
-      searchValue: "const test = require('test-lib');",
-      replaceValue: "import test from 'test-lib';",
-    });
-
-    const result = await (plugin.renderChunk as unknown as RenderChunk).call(
-      context,
-      "const test = require('test-lib');",
-      { facadeModuleId: '' } as RenderedChunk,
-    );
-
-    expect(result).toBeNull();
-    expect(context.warn).not.toHaveBeenCalled();
-    expect(context.info).not.toHaveBeenCalled();
   });
 });

--- a/packages/@wdio_electron-bundler/test/utils.spec.ts
+++ b/packages/@wdio_electron-bundler/test/utils.spec.ts
@@ -8,380 +8,382 @@ vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
 }));
 
-describe('getInputConfig', () => {
-  beforeEach(() => {
-    vi.mocked(existsSync).mockReset();
-  });
-
-  it('should resolve entry points from exports field', () => {
-    vi.mocked(existsSync).mockImplementation((path: PathLike) => {
-      const normalizedPath = path.toString().replace(/\\/g, '/');
-      return (
-        normalizedPath.endsWith('src/index.ts') ||
-        normalizedPath.endsWith('src/mod1.ts') ||
-        normalizedPath.endsWith('src/mod2/index.ts') ||
-        normalizedPath.endsWith('src/mod3.mts') ||
-        normalizedPath.endsWith('src/mod4/index.mts') ||
-        normalizedPath.endsWith('src/mod5/api.cts') ||
-        normalizedPath.endsWith('src/mod6/api/index.cts')
-      );
+describe('Utility Functions', () => {
+  describe('getInputConfig()', () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReset();
     });
 
-    const pkgJsonPath = getFixturePackagePath('esm', 'build-test-esm');
-    const exports = {
-      '.': './dist/loader.js',
-      './mod1': './dist/mod1.js',
-      './mod2': {
-        import: {
-          types: './dist/mod2/index.d.ts',
-          default: './dist/mod2/index.js',
-        },
-        require: {
-          types: './dist/mod2/index.d.ts',
-          default: './dist/mod2/index.js',
-        },
-      },
-      './mod3': {
-        import: {
-          types: './dist/mod3.d.mts',
-          default: './dist/mod3.mjs',
-        },
-        require: {
-          types: './dist/mod3.d.cts',
-          default: './dist/mod3.cjs',
-        },
-      },
-      './mod4': './dist/mod4/index.mjs',
-      './mod5/api': {
-        import: {
-          types: './dist/mod5/api.d.mts',
-          default: './dist/mod5/api.mjs',
-        },
-        require: {
-          types: './dist/mod5/api.d.cts',
-          default: './dist/mod5/api.cjs',
-        },
-      },
-      './mod6/api': {
-        import: {
-          types: './dist/mod6/api/index.d.cts',
-          default: './dist/mod6/api/index.cjs',
-        },
-        require: {
-          types: './dist/mod6/api/index.d.cts',
-          default: './dist/mod6/api/index.cjs',
-        },
-      },
-    };
+    it('should resolve entry points from exports field', () => {
+      vi.mocked(existsSync).mockImplementation((path: PathLike) => {
+        const normalizedPath = path.toString().replace(/\\/g, '/');
+        return (
+          normalizedPath.endsWith('src/index.ts') ||
+          normalizedPath.endsWith('src/mod1.ts') ||
+          normalizedPath.endsWith('src/mod2/index.ts') ||
+          normalizedPath.endsWith('src/mod3.mts') ||
+          normalizedPath.endsWith('src/mod4/index.mts') ||
+          normalizedPath.endsWith('src/mod5/api.cts') ||
+          normalizedPath.endsWith('src/mod6/api/index.cts')
+        );
+      });
 
-    expect(
-      getInputConfig(
-        {
-          path: pkgJsonPath,
-          packageJson: {
-            name: 'test',
-            version: '0.0.0',
-            readme: 'readme.md',
-            _id: '',
-            exports,
+      const pkgJsonPath = getFixturePackagePath('esm', 'build-test-esm');
+      const exports = {
+        '.': './dist/loader.js',
+        './mod1': './dist/mod1.js',
+        './mod2': {
+          import: {
+            types: './dist/mod2/index.d.ts',
+            default: './dist/mod2/index.js',
+          },
+          require: {
+            types: './dist/mod2/index.d.ts',
+            default: './dist/mod2/index.js',
           },
         },
-        'src',
-      ),
-    ).toEqual({
-      'index': 'src/index.ts',
-      'mod1': 'src/mod1.ts',
-      'mod2': 'src/mod2/index.ts',
-      'mod3': 'src/mod3.mts',
-      'mod4': 'src/mod4/index.mts',
-      'mod5/api': 'src/mod5/api.cts',
-      'mod6/api': 'src/mod6/api/index.cts',
-    });
-  });
-
-  it('should throw an error when exports field is missing', () => {
-    expect(() =>
-      getInputConfig(
-        {
-          path: '/path/to/package.json',
-          packageJson: {
-            name: 'test',
-            version: '0.0.0',
-            readme: 'readme.md',
-            _id: '',
+        './mod3': {
+          import: {
+            types: './dist/mod3.d.mts',
+            default: './dist/mod3.mjs',
+          },
+          require: {
+            types: './dist/mod3.d.cts',
+            default: './dist/mod3.cjs',
           },
         },
-        'src',
-      ),
-    ).toThrowError(`"exports" field which is required is not set:`);
-  });
-
-  it('should throw an error when entry point is not found', () => {
-    const exports = {
-      '.': {
-        import: {
-          types: './dist/index.d.mts',
-          default: './dist/index.mjs',
-        },
-        require: {
-          types: './dist/index.d.cts',
-          default: './dist/index.cjs',
-        },
-      },
-    };
-    expect(() =>
-      getInputConfig(
-        {
-          path: '/path/to/package.json',
-          packageJson: {
-            name: 'test',
-            version: '0.0.0',
-            readme: 'readme.md',
-            _id: '',
-            exports,
+        './mod4': './dist/mod4/index.mjs',
+        './mod5/api': {
+          import: {
+            types: './dist/mod5/api.d.mts',
+            default: './dist/mod5/api.mjs',
+          },
+          require: {
+            types: './dist/mod5/api.d.cts',
+            default: './dist/mod5/api.cjs',
           },
         },
-        'src',
-      ),
-    ).toThrowError(`entry point is not found: `);
-  });
-
-  it('should resolve entry points from nested import/require fields', () => {
-    vi.mocked(existsSync).mockImplementation((path: PathLike) => {
-      const normalizedPath = path.toString().replace(/\\/g, '/');
-      return (
-        normalizedPath.endsWith('src/nested.ts') ||
-        normalizedPath.endsWith('src/deep.ts') ||
-        normalizedPath.endsWith('src/index.ts')
-      );
-    });
-
-    const exports = {
-      '.': './dist/loader.js',
-      './nested': './dist/nested.js',
-      './deep': './dist/deep.js',
-    };
-
-    expect(
-      getInputConfig(
-        {
-          path: '/path/to/package.json',
-          packageJson: {
-            name: 'test',
-            version: '0.0.0',
-            readme: 'readme.md',
-            _id: '',
-            exports,
+        './mod6/api': {
+          import: {
+            types: './dist/mod6/api/index.d.cts',
+            default: './dist/mod6/api/index.cjs',
+          },
+          require: {
+            types: './dist/mod6/api/index.d.cts',
+            default: './dist/mod6/api/index.cjs',
           },
         },
-        'src',
-      ),
-    ).toEqual({
-      index: 'src/index.ts',
-      nested: 'src/nested.ts',
-      deep: 'src/deep.ts',
-    });
-  });
+      };
 
-  it('should handle entry points with only import field', () => {
-    vi.mocked(existsSync).mockImplementation((path: PathLike) => {
-      const normalizedPath = path.toString().replace(/\\/g, '/');
-      return normalizedPath.endsWith('src/importOnly.ts') || normalizedPath.endsWith('src/index.ts');
-    });
-
-    const exports = {
-      '.': './dist/loader.js',
-      './importOnly': './dist/importOnly.js',
-    };
-
-    expect(
-      getInputConfig(
-        {
-          path: '/path/to/package.json',
-          packageJson: {
-            name: 'test',
-            version: '0.0.0',
-            readme: 'readme.md',
-            _id: '',
-            exports,
-          },
-        },
-        'src',
-      ),
-    ).toEqual({
-      index: 'src/index.ts',
-      importOnly: 'src/importOnly.ts',
-    });
-  });
-
-  it('should handle entry points with only require field', () => {
-    vi.mocked(existsSync).mockImplementation((path: PathLike) => {
-      const normalizedPath = path.toString().replace(/\\/g, '/');
-      return normalizedPath.endsWith('src/requireOnly.ts') || normalizedPath.endsWith('src/index.ts');
-    });
-
-    const exports = {
-      '.': './dist/loader.js',
-      './requireOnly': './dist/requireOnly.js',
-    };
-
-    expect(
-      getInputConfig(
-        {
-          path: '/path/to/package.json',
-          packageJson: {
-            name: 'test',
-            version: '0.0.0',
-            readme: 'readme.md',
-            _id: '',
-            exports,
-          },
-        },
-        'src',
-      ),
-    ).toEqual({
-      index: 'src/index.ts',
-      requireOnly: 'src/requireOnly.ts',
-    });
-  });
-});
-
-describe('getOutDirs', () => {
-  const fixturePkgJson = {
-    name: 'test-pkg',
-    version: '0.0.0',
-    readme: 'readme.md',
-    _id: '',
-    main: './path/to/cjs/index.js',
-    module: './path/to/esm/index.js',
-    types: './path/to/types/index.d.js',
-  };
-
-  it.each(['main', 'module'] as const)('should throw an error when the %s field is missing', (fieldName) => {
-    const testPackageJson = Object.assign({}, fixturePkgJson);
-    delete testPackageJson[fieldName];
-
-    expect(() =>
-      getOutDirs({
-        packageJson: testPackageJson,
-        path: '/path/to/package.json',
-      }),
-    ).toThrowError(`"${fieldName}" field which is required is not set:`);
-  });
-
-  it('should return correct output directory paths', () => {
-    expect(
-      getOutDirs({
-        packageJson: fixturePkgJson,
-        path: '/path/to/package.json',
-      }),
-    ).toStrictEqual({
-      esm: './path/to/esm',
-      cjs: './path/to/cjs',
-    });
-  });
-});
-
-describe('injectDependency', () => {
-  vi.mock('rollup', async (importOriginal) => {
-    const actualRollup = await importOriginal<typeof import('rollup')>();
-    return {
-      ...actualRollup,
-      rollup: vi.fn(async () => ({
-        generate: vi.fn(async () => ({
-          output: [
-            {
-              code: 'const obj = {\n  a: 1,\n  b: 2,\n};\n\nexport { obj };\n',
+      expect(
+        getInputConfig(
+          {
+            path: pkgJsonPath,
+            packageJson: {
+              name: 'test',
+              version: '0.0.0',
+              readme: 'readme.md',
+              _id: '',
+              exports,
             },
-          ],
+          },
+          'src',
+        ),
+      ).toEqual({
+        'index': 'src/index.ts',
+        'mod1': 'src/mod1.ts',
+        'mod2': 'src/mod2/index.ts',
+        'mod3': 'src/mod3.mts',
+        'mod4': 'src/mod4/index.mts',
+        'mod5/api': 'src/mod5/api.cts',
+        'mod6/api': 'src/mod6/api/index.cts',
+      });
+    });
+
+    it('should throw an error when exports field is missing', () => {
+      expect(() =>
+        getInputConfig(
+          {
+            path: '/path/to/package.json',
+            packageJson: {
+              name: 'test',
+              version: '0.0.0',
+              readme: 'readme.md',
+              _id: '',
+            },
+          },
+          'src',
+        ),
+      ).toThrowError(`"exports" field which is required is not set:`);
+    });
+
+    it('should throw an error when entry point is not found', () => {
+      const exports = {
+        '.': {
+          import: {
+            types: './dist/index.d.mts',
+            default: './dist/index.mjs',
+          },
+          require: {
+            types: './dist/index.d.cts',
+            default: './dist/index.cjs',
+          },
+        },
+      };
+      expect(() =>
+        getInputConfig(
+          {
+            path: '/path/to/package.json',
+            packageJson: {
+              name: 'test',
+              version: '0.0.0',
+              readme: 'readme.md',
+              _id: '',
+              exports,
+            },
+          },
+          'src',
+        ),
+      ).toThrowError(`entry point is not found: `);
+    });
+
+    it('should resolve entry points from nested import/require fields', () => {
+      vi.mocked(existsSync).mockImplementation((path: PathLike) => {
+        const normalizedPath = path.toString().replace(/\\/g, '/');
+        return (
+          normalizedPath.endsWith('src/nested.ts') ||
+          normalizedPath.endsWith('src/deep.ts') ||
+          normalizedPath.endsWith('src/index.ts')
+        );
+      });
+
+      const exports = {
+        '.': './dist/loader.js',
+        './nested': './dist/nested.js',
+        './deep': './dist/deep.js',
+      };
+
+      expect(
+        getInputConfig(
+          {
+            path: '/path/to/package.json',
+            packageJson: {
+              name: 'test',
+              version: '0.0.0',
+              readme: 'readme.md',
+              _id: '',
+              exports,
+            },
+          },
+          'src',
+        ),
+      ).toEqual({
+        index: 'src/index.ts',
+        nested: 'src/nested.ts',
+        deep: 'src/deep.ts',
+      });
+    });
+
+    it('should handle entry points with only import field', () => {
+      vi.mocked(existsSync).mockImplementation((path: PathLike) => {
+        const normalizedPath = path.toString().replace(/\\/g, '/');
+        return normalizedPath.endsWith('src/importOnly.ts') || normalizedPath.endsWith('src/index.ts');
+      });
+
+      const exports = {
+        '.': './dist/loader.js',
+        './importOnly': './dist/importOnly.js',
+      };
+
+      expect(
+        getInputConfig(
+          {
+            path: '/path/to/package.json',
+            packageJson: {
+              name: 'test',
+              version: '0.0.0',
+              readme: 'readme.md',
+              _id: '',
+              exports,
+            },
+          },
+          'src',
+        ),
+      ).toEqual({
+        index: 'src/index.ts',
+        importOnly: 'src/importOnly.ts',
+      });
+    });
+
+    it('should handle entry points with only require field', () => {
+      vi.mocked(existsSync).mockImplementation((path: PathLike) => {
+        const normalizedPath = path.toString().replace(/\\/g, '/');
+        return normalizedPath.endsWith('src/requireOnly.ts') || normalizedPath.endsWith('src/index.ts');
+      });
+
+      const exports = {
+        '.': './dist/loader.js',
+        './requireOnly': './dist/requireOnly.js',
+      };
+
+      expect(
+        getInputConfig(
+          {
+            path: '/path/to/package.json',
+            packageJson: {
+              name: 'test',
+              version: '0.0.0',
+              readme: 'readme.md',
+              _id: '',
+              exports,
+            },
+          },
+          'src',
+        ),
+      ).toEqual({
+        index: 'src/index.ts',
+        requireOnly: 'src/requireOnly.ts',
+      });
+    });
+  });
+
+  describe('getOutDirs()', () => {
+    const fixturePkgJson = {
+      name: 'test-pkg',
+      version: '0.0.0',
+      readme: 'readme.md',
+      _id: '',
+      main: './path/to/cjs/index.js',
+      module: './path/to/esm/index.js',
+      types: './path/to/types/index.d.js',
+    };
+
+    it.each(['main', 'module'] as const)('should throw an error when the %s field is missing', (fieldName) => {
+      const testPackageJson = Object.assign({}, fixturePkgJson);
+      delete testPackageJson[fieldName];
+
+      expect(() =>
+        getOutDirs({
+          packageJson: testPackageJson,
+          path: '/path/to/package.json',
+        }),
+      ).toThrowError(`"${fieldName}" field which is required is not set:`);
+    });
+
+    it('should return correct output directory paths', () => {
+      expect(
+        getOutDirs({
+          packageJson: fixturePkgJson,
+          path: '/path/to/package.json',
+        }),
+      ).toStrictEqual({
+        esm: './path/to/esm',
+        cjs: './path/to/cjs',
+      });
+    });
+  });
+
+  describe('injectDependency()', () => {
+    vi.mock('rollup', async (importOriginal) => {
+      const actualRollup = await importOriginal<typeof import('rollup')>();
+      return {
+        ...actualRollup,
+        rollup: vi.fn(async () => ({
+          generate: vi.fn(async () => ({
+            output: [
+              {
+                code: 'const obj = {\n  a: 1,\n  b: 2,\n};\n\nexport { obj };\n',
+              },
+            ],
+          })),
         })),
-      })),
-    };
-  });
+      };
+    });
 
-  it('should successfully inject dependency code', async () => {
-    const fixture = getFixturePackagePath('esm', 'build-success-esm');
-    const cwd = dirname(fixture);
-    const context = {
-      resolve: vi.fn().mockResolvedValue({ id: `${cwd}/src/test.js` }),
-      info: vi.fn(),
-      error: vi.fn(),
-    } as unknown as PluginContext;
-    const templateContent = `const obj = await import('./test.js');`;
+    it('should successfully inject dependency code', async () => {
+      const fixture = getFixturePackagePath('esm', 'build-success-esm');
+      const cwd = dirname(fixture);
+      const context = {
+        resolve: vi.fn().mockResolvedValue({ id: `${cwd}/src/test.js` }),
+        info: vi.fn(),
+        error: vi.fn(),
+      } as unknown as PluginContext;
+      const templateContent = `const obj = await import('./test.js');`;
 
-    const param: InjectDependencyPluginOptions = {
-      packageName: './test.js',
-      targetFile: 'main.ts',
-      bundleRegExp: /export/,
-      importName: 'obj',
-      bundleReplace: (importName: string) => `const ${importName} =`,
-    };
+      const param: InjectDependencyPluginOptions = {
+        packageName: './test.js',
+        targetFile: 'main.ts',
+        bundleRegExp: /export/,
+        importName: 'obj',
+        bundleReplace: (importName: string) => `const ${importName} =`,
+      };
 
-    const code = await injectDependency.call(context, param, templateContent);
-    expect(code).toBe('const obj = {\n  a: 1,\n  b: 2,\n};\n\nconst obj = { obj };\n');
-  });
+      const code = await injectDependency.call(context, param, templateContent);
+      expect(code).toBe('const obj = {\n  a: 1,\n  b: 2,\n};\n\nconst obj = { obj };\n');
+    });
 
-  it('should error when the package cannot be resolved', async () => {
-    const context = {
-      resolve: vi.fn().mockResolvedValue(undefined),
-      info: vi.fn(),
-      error: vi.fn(),
-    } as unknown as PluginContext;
+    it('should error when the package cannot be resolved', async () => {
+      const context = {
+        resolve: vi.fn().mockResolvedValue(undefined),
+        info: vi.fn(),
+        error: vi.fn(),
+      } as unknown as PluginContext;
 
-    const templateContent = `const obj = await import('./test.js');`;
-    const param: InjectDependencyPluginOptions = {
-      packageName: './test.js',
-      targetFile: 'main.ts',
-      importName: 'obj',
-      bundleRegExp: /export/,
-      bundleReplace: (importName: string) => `const ${importName} =`,
-    };
+      const templateContent = `const obj = await import('./test.js');`;
+      const param: InjectDependencyPluginOptions = {
+        packageName: './test.js',
+        targetFile: 'main.ts',
+        importName: 'obj',
+        bundleRegExp: /export/,
+        bundleReplace: (importName: string) => `const ${importName} =`,
+      };
 
-    await injectDependency.call(context, param, templateContent);
-    expect(context.error).toHaveBeenCalled();
-  });
+      await injectDependency.call(context, param, templateContent);
+      expect(context.error).toHaveBeenCalled();
+    });
 
-  it('should error when injected contents cannot be generated', async () => {
-    const fixture = getFixturePackagePath('esm', 'build-success-esm');
-    const cwd = dirname(fixture);
-    const context = {
-      resolve: vi.fn().mockResolvedValue({ id: `${cwd}/src/test.js` }),
-      info: vi.fn(),
-      error: vi.fn(),
-    } as unknown as PluginContext;
+    it('should error when injected contents cannot be generated', async () => {
+      const fixture = getFixturePackagePath('esm', 'build-success-esm');
+      const cwd = dirname(fixture);
+      const context = {
+        resolve: vi.fn().mockResolvedValue({ id: `${cwd}/src/test.js` }),
+        info: vi.fn(),
+        error: vi.fn(),
+      } as unknown as PluginContext;
 
-    const templateContent = `const obj = await import('./test.js');`;
-    const param: InjectDependencyPluginOptions = {
-      packageName: './test.js',
-      targetFile: 'main.ts',
-      importName: 'obj',
-      bundleRegExp: /xxxxx/,
-      bundleReplace: (importName: string) => `const ${importName} =`,
-    };
+      const templateContent = `const obj = await import('./test.js');`;
+      const param: InjectDependencyPluginOptions = {
+        packageName: './test.js',
+        targetFile: 'main.ts',
+        importName: 'obj',
+        bundleRegExp: /xxxxx/,
+        bundleReplace: (importName: string) => `const ${importName} =`,
+      };
 
-    await injectDependency.call(context, param, templateContent);
-    expect(context.error).toHaveBeenCalled();
-  });
+      await injectDependency.call(context, param, templateContent);
+      expect(context.error).toHaveBeenCalled();
+    });
 
-  it('should error when rendered content cannot be generated', async () => {
-    const fixture = getFixturePackagePath('esm', 'build-success-esm');
-    const cwd = dirname(fixture);
-    const context = {
-      resolve: vi.fn().mockResolvedValue({ id: `${cwd}/src/test.js` }),
-      info: vi.fn(),
-      error: vi.fn(),
-    } as unknown as PluginContext;
+    it('should error when rendered content cannot be generated', async () => {
+      const fixture = getFixturePackagePath('esm', 'build-success-esm');
+      const cwd = dirname(fixture);
+      const context = {
+        resolve: vi.fn().mockResolvedValue({ id: `${cwd}/src/test.js` }),
+        info: vi.fn(),
+        error: vi.fn(),
+      } as unknown as PluginContext;
 
-    const templateContent = `const obj = await import('./test.js');`;
-    const param: InjectDependencyPluginOptions = {
-      packageName: './test.js',
-      targetFile: 'main.ts',
-      importName: 'xxxxx',
-      bundleRegExp: /export/,
-      bundleReplace: (importName: string) => `const ${importName} =`,
-    };
+      const templateContent = `const obj = await import('./test.js');`;
+      const param: InjectDependencyPluginOptions = {
+        packageName: './test.js',
+        targetFile: 'main.ts',
+        importName: 'xxxxx',
+        bundleRegExp: /export/,
+        bundleReplace: (importName: string) => `const ${importName} =`,
+      };
 
-    await injectDependency.call(context, param, templateContent);
-    expect(context.error).toHaveBeenCalled();
+      await injectDependency.call(context, param, templateContent);
+      expect(context.error).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/@wdio_electron-utils/test/index.spec.ts
+++ b/packages/@wdio_electron-utils/test/index.spec.ts
@@ -21,578 +21,175 @@ vi.mock('node:fs/promises', async (importOriginal) => {
   };
 });
 
-describe('getBinaryPath', () => {
-  const pkgJSONPath = '/foo/bar/package.json';
-  const winProcess = { platform: 'win32' } as NodeJS.Process;
-  const macProcess = { platform: 'darwin' } as NodeJS.Process;
-  const linuxProcess = { platform: 'linux' } as NodeJS.Process;
-  const unsupportedPlatformProcess = { platform: 'aix' } as NodeJS.Process;
-
-  function mockBinaryPath(binaryPath: string) {
-    (fs.access as Mock).mockImplementation((path: string) => {
-      if (path === binaryPath) {
-        return Promise.resolve();
-      } else {
-        return Promise.reject(new Error(`ENOENT: no such file or directory, access '${path}' !== '${binaryPath}'`));
-      }
-    });
-  }
-
-  it('should throw an error when provided with an unsupported platform', async () =>
-    expect(() =>
-      getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { packagerConfig: { name: 'my-app' } },
-          isForge: true,
-          isBuilder: false,
-        },
-        '29.3.1',
-        unsupportedPlatformProcess,
-      ),
-    ).rejects.toThrow('Unsupported platform: aix'));
-
-  it('should throw an error when no binary is found for a Forge setup', async () => {
-    const binaryPaths = [
-      path.join('/foo', 'bar', 'out', 'my-app-win32-ia32', 'my-app.exe'),
-      path.join('/foo', 'bar', 'out', 'my-app-win32-x64', 'my-app.exe'),
-      path.join('/foo', 'bar', 'out', 'my-app-win32-arm64', 'my-app.exe'),
-    ];
-    (fs.access as Mock).mockImplementation(() => Promise.reject(new Error('No such file or directory')));
-    await expect(
-      getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { packagerConfig: { name: 'my-app' } },
-          isForge: true,
-          isBuilder: false,
-        },
-        '29.3.1',
-        winProcess,
-      ),
-    ).rejects.toThrow(`No executable binary found, checked: \n${binaryPaths.join(', \n')}`);
-  });
-
-  it('should throw an error when no binary is found for a builder setup on MacOS', async () => {
-    const binaryPaths = [
-      path.join('/foo', 'bar', 'dist', 'mac-arm64', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
-      path.join('/foo', 'bar', 'dist', 'mac-armv7l', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
-      path.join('/foo', 'bar', 'dist', 'mac-ia32', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
-      path.join('/foo', 'bar', 'dist', 'mac-universal', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
-      path.join('/foo', 'bar', 'dist', 'mac', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
-    ];
-    (fs.access as Mock).mockImplementation(() => Promise.reject(new Error('No such file or directory')));
-    await expect(
-      getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { productName: 'my-app' },
-          isForge: false,
-          isBuilder: true,
-        },
-        '29.3.1',
-        macProcess,
-      ),
-    ).rejects.toThrow(`No executable binary found, checked: \n${binaryPaths.join(', \n')}`);
-  });
-
-  it('should throw an error when no binary is found for a Builder setup', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'dist', 'win-unpacked', 'my-app.exe');
-    (fs.access as Mock).mockImplementation(() => Promise.reject(new Error('No such file or directory')));
-    await expect(
-      getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { productName: 'my-app' },
-          isForge: false,
-          isBuilder: true,
-        },
-        '29.3.1',
-        winProcess,
-      ),
-    ).rejects.toThrow(`No executable binary found, checked: \n${binaryPath}`);
-  });
-
-  it('should return the expected app path for a Forge setup with multiple executable binaries', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'out', 'my-app-win32-ia32', 'my-app.exe');
-    (fs.access as Mock).mockImplementation(() => Promise.resolve());
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { packagerConfig: { name: 'my-app' } },
-          isForge: true,
-          isBuilder: false,
-        },
-        '29.3.1',
-        winProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a builder setup with multiple executable binaries', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'dist', 'mac-arm64', 'my-app.app', 'Contents', 'MacOS', 'my-app');
-    (fs.access as Mock).mockImplementation(() => Promise.resolve());
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { productName: 'my-app' },
-          isForge: false,
-          isBuilder: true,
-        },
-        '29.3.1',
-        macProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a Forge setup with custom output directory', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'custom-outdir', 'my-app-win32-x64', 'my-app.exe');
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { packagerConfig: { name: 'my-app' }, outDir: 'custom-outdir' },
-          isForge: true,
-          isBuilder: false,
-        },
-        '29.3.1',
-        winProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a Forge setup on Windows', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'out', 'my-app-win32-x64', 'my-app.exe');
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { packagerConfig: { name: 'my-app' } },
-          isForge: true,
-          isBuilder: false,
-        },
-        '29.3.1',
-        winProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a Forge setup on Arm Mac', async () => {
-    const binaryPath = path.join(
-      '/foo',
-      'bar',
-      'out',
-      'my-app-darwin-arm64',
-      'my-app.app',
-      'Contents',
-      'MacOS',
-      'my-app',
-    );
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { packagerConfig: { name: 'my-app' } },
-          isForge: true,
-          isBuilder: false,
-        },
-        '29.3.1',
-        macProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a Forge setup on Intel Mac', async () => {
-    const binaryPath = path.join(
-      '/foo',
-      'bar',
-      'out',
-      'my-app-darwin-x64',
-      'my-app.app',
-      'Contents',
-      'MacOS',
-      'my-app',
-    );
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { packagerConfig: { name: 'my-app' } },
-          isForge: true,
-          isBuilder: false,
-        },
-        '29.3.1',
-        macProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a Forge setup on Linux', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'out', 'my-app-linux-x64', 'my-app');
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { packagerConfig: { name: 'my-app' } },
-          isForge: true,
-          isBuilder: false,
-        },
-        '29.3.1',
-        linuxProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a builder setup with custom output directory', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'custom-outdir', 'win-unpacked', 'my-app.exe');
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { productName: 'my-app', directories: { output: 'custom-outdir' } },
-          isForge: false,
-          isBuilder: true,
-        },
-        '29.3.1',
-        winProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a builder setup on Windows', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'dist', 'win-unpacked', 'my-app.exe');
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { productName: 'my-app' },
-          isForge: false,
-          isBuilder: true,
-        },
-        '29.3.1',
-        winProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a builder setup on Arm Mac', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'dist', 'mac-arm64', 'my-app.app', 'Contents', 'MacOS', 'my-app');
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { productName: 'my-app' },
-          isForge: false,
-          isBuilder: true,
-        },
-        '29.3.1',
-        macProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a builder setup on Intel Mac', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'dist', 'mac', 'my-app.app', 'Contents', 'MacOS', 'my-app');
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { productName: 'my-app' },
-          isForge: false,
-          isBuilder: true,
-        },
-        '29.3.1',
-        macProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a builder setup on Mac (universal arch)', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'dist', 'mac-universal', 'my-app.app', 'Contents', 'MacOS', 'my-app');
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { productName: 'my-app' },
-          isForge: false,
-          isBuilder: true,
-        },
-        '29.3.1',
-        macProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-
-  it('should return the expected app path for a builder setup on Linux', async () => {
-    const binaryPath = path.join('/foo', 'bar', 'dist', 'linux-unpacked', 'my-app');
-    mockBinaryPath(binaryPath);
-    expect(
-      await getBinaryPath(
-        pkgJSONPath,
-        {
-          appName: 'my-app',
-          config: { productName: 'my-app' },
-          isForge: false,
-          isBuilder: true,
-        },
-        '29.3.1',
-        linuxProcess,
-      ),
-    ).toBe(binaryPath);
-  });
-});
-
-describe('getAppBuildInfo', () => {
-  describe('ESM', () => {
-    it('should throw an error when no build tools are found', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'no-build-tool');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(() =>
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(
-        'No build tool was detected, if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities.',
-      );
+describe('Electron Utilities', () => {
+  describe('getElectronVersion()', () => {
+    it('should return the electron version from package.json dependencies', async () => {
+      const pkg = {
+        packageJson: {
+          name: 'my-app',
+          version: '1.0.0',
+          dependencies: {
+            electron: '^29.4.1',
+          },
+        } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
+        path: '/path/to/package.json',
+      } as NormalizedReadResult;
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('29.4.1');
     });
 
-    it('should throw an error when dependencies for multiple build tools are found without configuration', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'multiple-build-tools-no-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(() =>
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)forge.config.js'./);
+    it('should return the electron version from package.json devDependencies', async () => {
+      const pkg = {
+        packageJson: {
+          name: 'my-app',
+          version: '1.0.0',
+          devDependencies: {
+            electron: '^29.4.1',
+          },
+        } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
+        path: '/path/to/package.json',
+      } as NormalizedReadResult;
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('29.4.1');
     });
 
-    it('should throw an error when the Forge app name is unable to be determined', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-inline-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      delete packageJson.name;
-      delete packageJson.config.forge.packagerConfig;
-      await expect(() =>
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(
-        'No application name was detected, please set name / productName in your package.json or build tool configuration.',
-      );
+    it('should return the nightly electron version from package.json dependencies', async () => {
+      const pkg = {
+        packageJson: {
+          name: 'my-app',
+          version: '1.0.0',
+          dependencies: {
+            'electron-nightly': '33.0.0-nightly.20240621',
+          },
+        } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
+        path: '/path/to/package.json',
+      } as NormalizedReadResult;
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('33.0.0-nightly.20240621');
     });
 
-    it('should throw an error when the builder app name is unable to be determined', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'builder-dependency-inline-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      delete packageJson.name;
-      delete packageJson.build.productName;
-      await expect(() =>
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(
-        'No application name was detected, please set name / productName in your package.json or build tool configuration.',
-      );
+    it('should return the nightly electron version from package.json devDependencies', async () => {
+      const pkg = {
+        packageJson: {
+          name: 'my-app',
+          version: '1.0.0',
+          devDependencies: {
+            'electron-nightly': '33.0.0-nightly.20240621',
+          },
+        } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
+        path: '/path/to/package.json',
+      } as NormalizedReadResult;
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('33.0.0-nightly.20240621');
     });
 
-    it('should throw an error when builder is detected but has no config', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'builder-dependency-no-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(
-        'Electron-builder was detected but no configuration was found, make sure your config file is named correctly, e.g. `electron-builder.config.json`.',
-      );
+    it('should return undefined when there is no electron dependency', async () => {
+      const pkg = {
+        packageJson: {
+          name: 'my-app',
+          version: '1.0.0',
+          dependencies: {},
+        } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
+        path: '/path/to/package.json',
+      } as NormalizedReadResult;
+      const version = await getElectronVersion(pkg);
+      expect(version).toBeUndefined();
     });
+  });
 
-    it('should throw an error when Forge is detected but has no config', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-no-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)forge.config.js'./);
-    });
-
-    it('should throw an error when Forge is detected with a linked JS config but the config file cannot be read', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-linked-js-config-broken');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)custom-config.js'./);
-    });
-
-    it('should return the expected config when configuration for builder is found alongside a Forge dependency', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'multiple-build-tools-wrong-config-1');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'multiple-build-tools-wrong-config-1',
-        config: { productName: 'multiple-build-tools-wrong-config-1' },
-        isBuilder: true,
-        isForge: false,
+  describe('getAppBuildInfo()', () => {
+    describe('ESM', () => {
+      it('should throw an error when no build tools are found', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'no-build-tool');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(() =>
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(
+          'No build tool was detected, if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities.',
+        );
       });
-    });
 
-    it('should return the expected config when configuration for Forge is found alongside a builder dependency', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'multiple-build-tools-wrong-config-2');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'multiple-build-tools-wrong-config-2',
-        config: { packagerConfig: { name: 'multiple-build-tools-wrong-config-2' } },
-        isBuilder: false,
-        isForge: true,
+      it('should throw an error when dependencies for multiple build tools are found without configuration', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'multiple-build-tools-no-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(() =>
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)forge.config.js'./);
       });
-    });
 
-    it('should return the expected config for a Forge dependency with JS config', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-js-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'forge-dependency-js-config',
-        config: { packagerConfig: { name: 'forge-dependency-js-config' } },
-        isBuilder: false,
-        isForge: true,
+      it('should throw an error when the Forge app name is unable to be determined', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-inline-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        delete packageJson.name;
+        delete packageJson.config.forge.packagerConfig;
+        await expect(() =>
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(
+          'No application name was detected, please set name / productName in your package.json or build tool configuration.',
+        );
       });
-    });
 
-    it('should return the expected config for a Forge dependency with linked JS config', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-linked-js-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'forge-dependency-linked-js-config',
-        config: { packagerConfig: { name: 'forge-dependency-linked-js-config' } },
-        isBuilder: false,
-        isForge: true,
+      it('should throw an error when the builder app name is unable to be determined', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'builder-dependency-inline-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        delete packageJson.name;
+        delete packageJson.build.productName;
+        await expect(() =>
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(
+          'No application name was detected, please set name / productName in your package.json or build tool configuration.',
+        );
       });
-    });
 
-    it('should try to access all variants of builder config files', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'builder-dependency-no-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      const spy = vi.spyOn(fs, 'access');
-      try {
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        });
-      } catch (_e) {
-        // An error will always occur because the configuration file does not exist.
-        // Ignore errors to test to ensure all expected filename patterns are covered
-      }
-      const accessedFilenames = spy.mock.calls.map((call) => {
-        if (typeof call[0] === 'string') {
-          return path.basename(call[0]);
-        }
-        assert.fail(`fs.access called with a non-string value: ${call[0]}`);
+      it('should throw an error when builder is detected but has no config', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'builder-dependency-no-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(
+          'Electron-builder was detected but no configuration was found, make sure your config file is named correctly, e.g. `electron-builder.config.json`.',
+        );
       });
-      const expected = [
-        'electron-builder.json',
-        'electron-builder.json5',
-        'electron-builder.yml',
-        'electron-builder.yaml',
-        'electron-builder.toml',
-        'electron-builder.js',
-        'electron-builder.ts',
-        'electron-builder.mjs',
-        'electron-builder.cjs',
-        'electron-builder.mts',
-        'electron-builder.cts',
-        'electron-builder.config.json',
-        'electron-builder.config.json5',
-        'electron-builder.config.yml',
-        'electron-builder.config.yaml',
-        'electron-builder.config.toml',
-        'electron-builder.config.js',
-        'electron-builder.config.ts',
-        'electron-builder.config.mjs',
-        'electron-builder.config.cjs',
-        'electron-builder.config.mts',
-        'electron-builder.config.cts',
-      ];
-      expect(spy).toHaveBeenCalledTimes(expected.length);
-      assert.deepEqual(accessedFilenames.sort(), expected.sort());
-    });
 
-    it.each([
-      ['CJS', 'cjs-config'], // .config.cjs (Function)
-      ['CTS', 'cts-config'], // .config.cts (Object)
-      ['Inline', 'inline-config'], // no config file
-      ['JS', 'js-config'], // .config.js (Function)
-      ['MJS', 'mjs-config'], // .config.mjs (Object)
-      ['MTS', 'mts-config'], // .config.mts (Object)
-      ['JSON', 'json-config'], // .config.json
-      ['JSON5', 'json5-config'], // .config.json5
-      ['TOML', 'toml-config'], // .config.toml
-      ['TS', 'ts-fn-config'], // .config.ts (Function)
-      ['TS', 'ts-obj-config'], // .config.ts (Object)
-      ['YAML (.yaml)', 'yaml-config'], // .config.yaml
-      ['YAML (.yml)', 'yml-config'], // .config.yml
-    ])(
-      'should return the expected config for a builder dependency with %s config - ESM',
-      async (_key, builderFixtureName) => {
-        const fixtureName = `builder-dependency-${builderFixtureName}`;
-        vi.mocked(fs.access).mockRestore();
+      it('should throw an error when Forge is detected but has no config', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-no-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)forge.config.js'./);
+      });
 
-        const packageJsonPath = getFixturePackagePath('esm', fixtureName);
+      it('should throw an error when Forge is detected with a linked JS config but the config file cannot be read', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-linked-js-config-broken');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)custom-config.js'./);
+      });
+
+      it('should return the expected config when configuration for builder is found alongside a Forge dependency', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'multiple-build-tools-wrong-config-1');
         const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
         await expect(
           await getAppBuildInfo({
@@ -600,285 +197,15 @@ describe('getAppBuildInfo', () => {
             path: packageJsonPath,
           }),
         ).toStrictEqual({
-          appName: fixtureName,
-          config: { productName: fixtureName },
+          appName: 'multiple-build-tools-wrong-config-1',
+          config: { productName: 'multiple-build-tools-wrong-config-1' },
           isBuilder: true,
           isForge: false,
         });
-      },
-    );
-
-    it('should return the expected config when there is no app name in the build tool config', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'no-app-name-in-build-tool-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'fixture-esm_no-app-name-in-build-tool-config',
-        config: { appId: 'no-app-name-in-build-tool-config' },
-        isBuilder: true,
-        isForge: false,
       });
-    });
 
-    it('should return the expected config for a Forge dependency with inline config', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-inline-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'forge-dependency-inline-config',
-        config: { packagerConfig: { name: 'forge-dependency-inline-config' } },
-        isBuilder: false,
-        isForge: true,
-      });
-    });
-
-    it('should return the expected config when configuration for multiple build tools are found', async () => {
-      const packageJsonPath = getFixturePackagePath('esm', 'multiple-build-tools-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'multiple-build-tools-config',
-        config: { packagerConfig: { name: 'multiple-build-tools-config' } },
-        isBuilder: false,
-        isForge: true,
-      });
-    });
-  });
-
-  describe('CJS', () => {
-    it('should throw an error when no build tools are found', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'no-build-tool');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(() =>
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(
-        'No build tool was detected, if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities.',
-      );
-    });
-
-    it('should throw an error when dependencies for multiple build tools are found without configuration', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'multiple-build-tools-no-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(() =>
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)forge.config.js'./);
-    });
-
-    it('should throw an error when the Forge app name is unable to be determined', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-inline-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      delete packageJson.name;
-      delete packageJson.config.forge.packagerConfig;
-      await expect(() =>
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(
-        'No application name was detected, please set name / productName in your package.json or build tool configuration.',
-      );
-    });
-
-    it('should throw an error when the builder app name is unable to be determined', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'builder-dependency-inline-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      delete packageJson.name;
-      delete packageJson.build.productName;
-      await expect(() =>
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(
-        'No application name was detected, please set name / productName in your package.json or build tool configuration.',
-      );
-    });
-
-    it('should throw an error when builder is detected but has no config', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'builder-dependency-no-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(
-        'Electron-builder was detected but no configuration was found, make sure your config file is named correctly, e.g. `electron-builder.config.json`.',
-      );
-    });
-
-    it('should throw an error when Forge is detected but has no config', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-no-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)forge.config.js'./);
-    });
-
-    it('should throw an error when Forge is detected with a linked JS config but the config file cannot be read', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-linked-js-config-broken');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)custom-config.js'./);
-    });
-
-    it('should return the expected config when configuration for builder is found alongside a Forge dependency', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'multiple-build-tools-wrong-config-1');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'multiple-build-tools-wrong-config-1',
-        config: { productName: 'multiple-build-tools-wrong-config-1' },
-        isBuilder: true,
-        isForge: false,
-      });
-    });
-
-    it('should return the expected config when configuration for Forge is found alongside a builder dependency', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'multiple-build-tools-wrong-config-2');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'multiple-build-tools-wrong-config-2',
-        config: { packagerConfig: { name: 'multiple-build-tools-wrong-config-2' } },
-        isBuilder: false,
-        isForge: true,
-      });
-    });
-
-    it('should return the expected config for a Forge dependency with JS config', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-js-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'forge-dependency-js-config',
-        config: { packagerConfig: { name: 'forge-dependency-js-config' } },
-        isBuilder: false,
-        isForge: true,
-      });
-    });
-
-    it('should return the expected config for a Forge dependency with linked JS config', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-linked-js-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'forge-dependency-linked-js-config',
-        config: { packagerConfig: { name: 'forge-dependency-linked-js-config' } },
-        isBuilder: false,
-        isForge: true,
-      });
-    });
-
-    it('should try to access all variants of builder config files', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'builder-dependency-no-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      const spy = vi.spyOn(fs, 'access');
-      try {
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        });
-      } catch (_e) {
-        // An error will always occur because the configuration file does not exist.
-        // Ignore errors to test to ensure all expected filename patterns are covered
-      }
-      const accessedFilenames = spy.mock.calls.map((call) => {
-        if (typeof call[0] === 'string') {
-          return path.basename(call[0]);
-        }
-        assert.fail(`fs.access called with a non-string value: ${call[0]}`);
-      });
-      const expected = [
-        'electron-builder.json',
-        'electron-builder.json5',
-        'electron-builder.yml',
-        'electron-builder.yaml',
-        'electron-builder.toml',
-        'electron-builder.js',
-        'electron-builder.ts',
-        'electron-builder.mjs',
-        'electron-builder.cjs',
-        'electron-builder.mts',
-        'electron-builder.cts',
-        'electron-builder.config.json',
-        'electron-builder.config.json5',
-        'electron-builder.config.yml',
-        'electron-builder.config.yaml',
-        'electron-builder.config.toml',
-        'electron-builder.config.js',
-        'electron-builder.config.ts',
-        'electron-builder.config.mjs',
-        'electron-builder.config.cjs',
-        'electron-builder.config.mts',
-        'electron-builder.config.cts',
-      ];
-      expect(spy).toHaveBeenCalledTimes(expected.length);
-      assert.deepEqual(accessedFilenames.sort(), expected.sort());
-    });
-
-    it.each([
-      ['CJS', 'cjs-config'], // .config.cjs (Function)
-      ['CTS', 'cts-config'], // .config.cts (Object)
-      ['Inline', 'inline-config'], // no config file
-      ['JS', 'js-config'], // .config.js (Function)
-      ['MJS', 'mjs-config'], // .config.mjs (Object)
-      ['MTS', 'mts-config'], // .config.mts (Object)
-      ['JSON', 'json-config'], // .config.json
-      ['JSON5', 'json5-config'], // .config.json5
-      ['TOML', 'toml-config'], // .config.toml
-      ['TS (fn)', 'ts-fn-config'], // .config.ts (Function)
-      ['TS (obj)', 'ts-obj-config'], // .config.ts (Object)
-      ['YAML (.yaml)', 'yaml-config'], // .config.yaml
-      ['YAML (.yml)', 'yml-config'], // .config.yml
-    ])(
-      'should return the expected config for a builder dependency with %s config',
-      async (_key, builderFixtureName) => {
-        const fixtureName = `builder-dependency-${builderFixtureName}`;
-        vi.mocked(fs.access).mockRestore();
-
-        const packageJsonPath = getFixturePackagePath('cjs', fixtureName);
+      it('should return the expected config when configuration for Forge is found alongside a builder dependency', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'multiple-build-tools-wrong-config-2');
         const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
         await expect(
           await getAppBuildInfo({
@@ -886,135 +213,810 @@ describe('getAppBuildInfo', () => {
             path: packageJsonPath,
           }),
         ).toStrictEqual({
-          appName: fixtureName,
-          config: { productName: fixtureName },
+          appName: 'multiple-build-tools-wrong-config-2',
+          config: { packagerConfig: { name: 'multiple-build-tools-wrong-config-2' } },
+          isBuilder: false,
+          isForge: true,
+        });
+      });
+
+      it('should return the expected config for a Forge dependency with JS config', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-js-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'forge-dependency-js-config',
+          config: { packagerConfig: { name: 'forge-dependency-js-config' } },
+          isBuilder: false,
+          isForge: true,
+        });
+      });
+
+      it('should return the expected config for a Forge dependency with linked JS config', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-linked-js-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'forge-dependency-linked-js-config',
+          config: { packagerConfig: { name: 'forge-dependency-linked-js-config' } },
+          isBuilder: false,
+          isForge: true,
+        });
+      });
+
+      it('should try to access all variants of builder config files', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'builder-dependency-no-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        const spy = vi.spyOn(fs, 'access');
+        try {
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          });
+        } catch (_e) {
+          // An error will always occur because the configuration file does not exist.
+          // Ignore errors to test to ensure all expected filename patterns are covered
+        }
+        const accessedFilenames = spy.mock.calls.map((call) => {
+          if (typeof call[0] === 'string') {
+            return path.basename(call[0]);
+          }
+          assert.fail(`fs.access called with a non-string value: ${call[0]}`);
+        });
+        const expected = [
+          'electron-builder.json',
+          'electron-builder.json5',
+          'electron-builder.yml',
+          'electron-builder.yaml',
+          'electron-builder.toml',
+          'electron-builder.js',
+          'electron-builder.ts',
+          'electron-builder.mjs',
+          'electron-builder.cjs',
+          'electron-builder.mts',
+          'electron-builder.cts',
+          'electron-builder.config.json',
+          'electron-builder.config.json5',
+          'electron-builder.config.yml',
+          'electron-builder.config.yaml',
+          'electron-builder.config.toml',
+          'electron-builder.config.js',
+          'electron-builder.config.ts',
+          'electron-builder.config.mjs',
+          'electron-builder.config.cjs',
+          'electron-builder.config.mts',
+          'electron-builder.config.cts',
+        ];
+        expect(spy).toHaveBeenCalledTimes(expected.length);
+        assert.deepEqual(accessedFilenames.sort(), expected.sort());
+      });
+
+      it.each([
+        ['CJS', 'cjs-config'], // .config.cjs (Function)
+        ['CTS', 'cts-config'], // .config.cts (Object)
+        ['Inline', 'inline-config'], // no config file
+        ['JS', 'js-config'], // .config.js (Function)
+        ['MJS', 'mjs-config'], // .config.mjs (Object)
+        ['MTS', 'mts-config'], // .config.mts (Object)
+        ['JSON', 'json-config'], // .config.json
+        ['JSON5', 'json5-config'], // .config.json5
+        ['TOML', 'toml-config'], // .config.toml
+        ['TS', 'ts-fn-config'], // .config.ts (Function)
+        ['TS', 'ts-obj-config'], // .config.ts (Object)
+        ['YAML (.yaml)', 'yaml-config'], // .config.yaml
+        ['YAML (.yml)', 'yml-config'], // .config.yml
+      ])(
+        'should return the expected config for a builder dependency with %s config - ESM',
+        async (_key, builderFixtureName) => {
+          const fixtureName = `builder-dependency-${builderFixtureName}`;
+          vi.mocked(fs.access).mockRestore();
+
+          const packageJsonPath = getFixturePackagePath('esm', fixtureName);
+          const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+          await expect(
+            await getAppBuildInfo({
+              packageJson,
+              path: packageJsonPath,
+            }),
+          ).toStrictEqual({
+            appName: fixtureName,
+            config: { productName: fixtureName },
+            isBuilder: true,
+            isForge: false,
+          });
+        },
+      );
+
+      it('should return the expected config when there is no app name in the build tool config', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'no-app-name-in-build-tool-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'fixture-esm_no-app-name-in-build-tool-config',
+          config: { appId: 'no-app-name-in-build-tool-config' },
           isBuilder: true,
           isForge: false,
         });
-      },
-    );
+      });
 
-    it('should return the expected config when there is no app name in the build tool config', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'no-app-name-in-build-tool-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'fixture-cjs_no-app-name-in-build-tool-config',
-        config: { appId: 'no-app-name-in-build-tool-config' },
-        isBuilder: true,
-        isForge: false,
+      it('should return the expected config for a Forge dependency with inline config', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'forge-dependency-inline-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'forge-dependency-inline-config',
+          config: { packagerConfig: { name: 'forge-dependency-inline-config' } },
+          isBuilder: false,
+          isForge: true,
+        });
+      });
+
+      it('should return the expected config when configuration for multiple build tools are found', async () => {
+        const packageJsonPath = getFixturePackagePath('esm', 'multiple-build-tools-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'multiple-build-tools-config',
+          config: { packagerConfig: { name: 'multiple-build-tools-config' } },
+          isBuilder: false,
+          isForge: true,
+        });
       });
     });
 
-    it('should return the expected config for a Forge dependency with inline config', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-inline-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'forge-dependency-inline-config',
-        config: { packagerConfig: { name: 'forge-dependency-inline-config' } },
-        isBuilder: false,
-        isForge: true,
+    describe('CJS', () => {
+      it('should throw an error when no build tools are found', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'no-build-tool');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(() =>
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(
+          'No build tool was detected, if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities.',
+        );
+      });
+
+      it('should throw an error when dependencies for multiple build tools are found without configuration', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'multiple-build-tools-no-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(() =>
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)forge.config.js'./);
+      });
+
+      it('should throw an error when the Forge app name is unable to be determined', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-inline-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        delete packageJson.name;
+        delete packageJson.config.forge.packagerConfig;
+        await expect(() =>
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(
+          'No application name was detected, please set name / productName in your package.json or build tool configuration.',
+        );
+      });
+
+      it('should throw an error when the builder app name is unable to be determined', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'builder-dependency-inline-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        delete packageJson.name;
+        delete packageJson.build.productName;
+        await expect(() =>
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(
+          'No application name was detected, please set name / productName in your package.json or build tool configuration.',
+        );
+      });
+
+      it('should throw an error when builder is detected but has no config', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'builder-dependency-no-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(
+          'Electron-builder was detected but no configuration was found, make sure your config file is named correctly, e.g. `electron-builder.config.json`.',
+        );
+      });
+
+      it('should throw an error when Forge is detected but has no config', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-no-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)forge.config.js'./);
+      });
+
+      it('should throw an error when Forge is detected with a linked JS config but the config file cannot be read', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-linked-js-config-broken');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).rejects.toThrow(/Forge was detected but no configuration was found at '(.*)custom-config.js'./);
+      });
+
+      it('should return the expected config when configuration for builder is found alongside a Forge dependency', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'multiple-build-tools-wrong-config-1');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'multiple-build-tools-wrong-config-1',
+          config: { productName: 'multiple-build-tools-wrong-config-1' },
+          isBuilder: true,
+          isForge: false,
+        });
+      });
+
+      it('should return the expected config when configuration for Forge is found alongside a builder dependency', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'multiple-build-tools-wrong-config-2');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'multiple-build-tools-wrong-config-2',
+          config: { packagerConfig: { name: 'multiple-build-tools-wrong-config-2' } },
+          isBuilder: false,
+          isForge: true,
+        });
+      });
+
+      it('should return the expected config for a Forge dependency with JS config', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-js-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'forge-dependency-js-config',
+          config: { packagerConfig: { name: 'forge-dependency-js-config' } },
+          isBuilder: false,
+          isForge: true,
+        });
+      });
+
+      it('should return the expected config for a Forge dependency with linked JS config', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-linked-js-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'forge-dependency-linked-js-config',
+          config: { packagerConfig: { name: 'forge-dependency-linked-js-config' } },
+          isBuilder: false,
+          isForge: true,
+        });
+      });
+
+      it('should try to access all variants of builder config files', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'builder-dependency-no-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        const spy = vi.spyOn(fs, 'access');
+        try {
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          });
+        } catch (_e) {
+          // An error will always occur because the configuration file does not exist.
+          // Ignore errors to test to ensure all expected filename patterns are covered
+        }
+        const accessedFilenames = spy.mock.calls.map((call) => {
+          if (typeof call[0] === 'string') {
+            return path.basename(call[0]);
+          }
+          assert.fail(`fs.access called with a non-string value: ${call[0]}`);
+        });
+        const expected = [
+          'electron-builder.json',
+          'electron-builder.json5',
+          'electron-builder.yml',
+          'electron-builder.yaml',
+          'electron-builder.toml',
+          'electron-builder.js',
+          'electron-builder.ts',
+          'electron-builder.mjs',
+          'electron-builder.cjs',
+          'electron-builder.mts',
+          'electron-builder.cts',
+          'electron-builder.config.json',
+          'electron-builder.config.json5',
+          'electron-builder.config.yml',
+          'electron-builder.config.yaml',
+          'electron-builder.config.toml',
+          'electron-builder.config.js',
+          'electron-builder.config.ts',
+          'electron-builder.config.mjs',
+          'electron-builder.config.cjs',
+          'electron-builder.config.mts',
+          'electron-builder.config.cts',
+        ];
+        expect(spy).toHaveBeenCalledTimes(expected.length);
+        assert.deepEqual(accessedFilenames.sort(), expected.sort());
+      });
+
+      it.each([
+        ['CJS', 'cjs-config'], // .config.cjs (Function)
+        ['CTS', 'cts-config'], // .config.cts (Object)
+        ['Inline', 'inline-config'], // no config file
+        ['JS', 'js-config'], // .config.js (Function)
+        ['MJS', 'mjs-config'], // .config.mjs (Object)
+        ['MTS', 'mts-config'], // .config.mts (Object)
+        ['JSON', 'json-config'], // .config.json
+        ['JSON5', 'json5-config'], // .config.json5
+        ['TOML', 'toml-config'], // .config.toml
+        ['TS (fn)', 'ts-fn-config'], // .config.ts (Function)
+        ['TS (obj)', 'ts-obj-config'], // .config.ts (Object)
+        ['YAML (.yaml)', 'yaml-config'], // .config.yaml
+        ['YAML (.yml)', 'yml-config'], // .config.yml
+      ])(
+        'should return the expected config for a builder dependency with %s config',
+        async (_key, builderFixtureName) => {
+          const fixtureName = `builder-dependency-${builderFixtureName}`;
+          vi.mocked(fs.access).mockRestore();
+
+          const packageJsonPath = getFixturePackagePath('cjs', fixtureName);
+          const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+          await expect(
+            await getAppBuildInfo({
+              packageJson,
+              path: packageJsonPath,
+            }),
+          ).toStrictEqual({
+            appName: fixtureName,
+            config: { productName: fixtureName },
+            isBuilder: true,
+            isForge: false,
+          });
+        },
+      );
+
+      it('should return the expected config when there is no app name in the build tool config', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'no-app-name-in-build-tool-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'fixture-cjs_no-app-name-in-build-tool-config',
+          config: { appId: 'no-app-name-in-build-tool-config' },
+          isBuilder: true,
+          isForge: false,
+        });
+      });
+
+      it('should return the expected config for a Forge dependency with inline config', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'forge-dependency-inline-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'forge-dependency-inline-config',
+          config: { packagerConfig: { name: 'forge-dependency-inline-config' } },
+          isBuilder: false,
+          isForge: true,
+        });
+      });
+
+      it('should return the expected config when configuration for multiple build tools are found', async () => {
+        const packageJsonPath = getFixturePackagePath('cjs', 'multiple-build-tools-config');
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+        await expect(
+          await getAppBuildInfo({
+            packageJson,
+            path: packageJsonPath,
+          }),
+        ).toStrictEqual({
+          appName: 'multiple-build-tools-config',
+          config: { packagerConfig: { name: 'multiple-build-tools-config' } },
+          isBuilder: false,
+          isForge: true,
+        });
       });
     });
+  });
 
-    it('should return the expected config when configuration for multiple build tools are found', async () => {
-      const packageJsonPath = getFixturePackagePath('cjs', 'multiple-build-tools-config');
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-      await expect(
-        await getAppBuildInfo({
-          packageJson,
-          path: packageJsonPath,
-        }),
-      ).toStrictEqual({
-        appName: 'multiple-build-tools-config',
-        config: { packagerConfig: { name: 'multiple-build-tools-config' } },
-        isBuilder: false,
-        isForge: true,
+  describe('getBinaryPath()', () => {
+    const pkgJSONPath = '/foo/bar/package.json';
+    const winProcess = { platform: 'win32' } as NodeJS.Process;
+    const macProcess = { platform: 'darwin' } as NodeJS.Process;
+    const linuxProcess = { platform: 'linux' } as NodeJS.Process;
+    const unsupportedPlatformProcess = { platform: 'aix' } as NodeJS.Process;
+
+    function mockBinaryPath(binaryPath: string) {
+      (fs.access as Mock).mockImplementation((path: string) => {
+        if (path === binaryPath) {
+          return Promise.resolve();
+        } else {
+          return Promise.reject(new Error(`ENOENT: no such file or directory, access '${path}' !== '${binaryPath}'`));
+        }
       });
+    }
+
+    it('should throw an error when provided with an unsupported platform', async () =>
+      expect(() =>
+        getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { packagerConfig: { name: 'my-app' } },
+            isForge: true,
+            isBuilder: false,
+          },
+          '29.3.1',
+          unsupportedPlatformProcess,
+        ),
+      ).rejects.toThrow('Unsupported platform: aix'));
+
+    it('should throw an error when no binary is found for a Forge setup', async () => {
+      const binaryPaths = [
+        path.join('/foo', 'bar', 'out', 'my-app-win32-ia32', 'my-app.exe'),
+        path.join('/foo', 'bar', 'out', 'my-app-win32-x64', 'my-app.exe'),
+        path.join('/foo', 'bar', 'out', 'my-app-win32-arm64', 'my-app.exe'),
+      ];
+      (fs.access as Mock).mockImplementation(() => Promise.reject(new Error('No such file or directory')));
+      await expect(
+        getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { packagerConfig: { name: 'my-app' } },
+            isForge: true,
+            isBuilder: false,
+          },
+          '29.3.1',
+          winProcess,
+        ),
+      ).rejects.toThrow(`No executable binary found, checked: \n${binaryPaths.join(', \n')}`);
     });
-  });
-});
 
-describe('getElectronVersion', () => {
-  it('should return the electron version from package.json dependencies', async () => {
-    const pkg = {
-      packageJson: {
-        name: 'my-app',
-        version: '1.0.0',
-        dependencies: {
-          electron: '^29.4.1',
-        },
-      } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
-      path: '/path/to/package.json',
-    } as NormalizedReadResult;
-    const version = await getElectronVersion(pkg);
-    expect(version).toBe('29.4.1');
-  });
+    it('should throw an error when no binary is found for a builder setup on MacOS', async () => {
+      const binaryPaths = [
+        path.join('/foo', 'bar', 'dist', 'mac-arm64', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
+        path.join('/foo', 'bar', 'dist', 'mac-armv7l', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
+        path.join('/foo', 'bar', 'dist', 'mac-ia32', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
+        path.join('/foo', 'bar', 'dist', 'mac-universal', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
+        path.join('/foo', 'bar', 'dist', 'mac', 'my-app.app', 'Contents', 'MacOS', 'my-app'),
+      ];
+      (fs.access as Mock).mockImplementation(() => Promise.reject(new Error('No such file or directory')));
+      await expect(
+        getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { productName: 'my-app' },
+            isForge: false,
+            isBuilder: true,
+          },
+          '29.3.1',
+          macProcess,
+        ),
+      ).rejects.toThrow(`No executable binary found, checked: \n${binaryPaths.join(', \n')}`);
+    });
 
-  it('should return the electron version from package.json devDependencies', async () => {
-    const pkg = {
-      packageJson: {
-        name: 'my-app',
-        version: '1.0.0',
-        devDependencies: {
-          electron: '^29.4.1',
-        },
-      } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
-      path: '/path/to/package.json',
-    } as NormalizedReadResult;
-    const version = await getElectronVersion(pkg);
-    expect(version).toBe('29.4.1');
-  });
+    it('should throw an error when no binary is found for a Builder setup', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'dist', 'win-unpacked', 'my-app.exe');
+      (fs.access as Mock).mockImplementation(() => Promise.reject(new Error('No such file or directory')));
+      await expect(
+        getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { productName: 'my-app' },
+            isForge: false,
+            isBuilder: true,
+          },
+          '29.3.1',
+          winProcess,
+        ),
+      ).rejects.toThrow(`No executable binary found, checked: \n${binaryPath}`);
+    });
 
-  it('should return the nightly electron version from package.json dependencies', async () => {
-    const pkg = {
-      packageJson: {
-        name: 'my-app',
-        version: '1.0.0',
-        dependencies: {
-          'electron-nightly': '33.0.0-nightly.20240621',
-        },
-      } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
-      path: '/path/to/package.json',
-    } as NormalizedReadResult;
-    const version = await getElectronVersion(pkg);
-    expect(version).toBe('33.0.0-nightly.20240621');
-  });
+    it('should return the expected app path for a Forge setup with multiple executable binaries', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'out', 'my-app-win32-ia32', 'my-app.exe');
+      (fs.access as Mock).mockImplementation(() => Promise.resolve());
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { packagerConfig: { name: 'my-app' } },
+            isForge: true,
+            isBuilder: false,
+          },
+          '29.3.1',
+          winProcess,
+        ),
+      ).toBe(binaryPath);
+    });
 
-  it('should return the nightly electron version from package.json devDependencies', async () => {
-    const pkg = {
-      packageJson: {
-        name: 'my-app',
-        version: '1.0.0',
-        devDependencies: {
-          'electron-nightly': '33.0.0-nightly.20240621',
-        },
-      } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
-      path: '/path/to/package.json',
-    } as NormalizedReadResult;
-    const version = await getElectronVersion(pkg);
-    expect(version).toBe('33.0.0-nightly.20240621');
-  });
+    it('should return the expected app path for a builder setup with multiple executable binaries', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'dist', 'mac-arm64', 'my-app.app', 'Contents', 'MacOS', 'my-app');
+      (fs.access as Mock).mockImplementation(() => Promise.resolve());
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { productName: 'my-app' },
+            isForge: false,
+            isBuilder: true,
+          },
+          '29.3.1',
+          macProcess,
+        ),
+      ).toBe(binaryPath);
+    });
 
-  it('should return undefined when there is no electron dependency', async () => {
-    const pkg = {
-      packageJson: {
-        name: 'my-app',
-        version: '1.0.0',
-        dependencies: {},
-      } as Omit<NormalizedPackageJson, 'readme' | '_id'>,
-      path: '/path/to/package.json',
-    } as NormalizedReadResult;
-    const version = await getElectronVersion(pkg);
-    expect(version).toBeUndefined();
+    it('should return the expected app path for a Forge setup with custom output directory', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'custom-outdir', 'my-app-win32-x64', 'my-app.exe');
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { packagerConfig: { name: 'my-app' }, outDir: 'custom-outdir' },
+            isForge: true,
+            isBuilder: false,
+          },
+          '29.3.1',
+          winProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a Forge setup on Windows', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'out', 'my-app-win32-x64', 'my-app.exe');
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { packagerConfig: { name: 'my-app' } },
+            isForge: true,
+            isBuilder: false,
+          },
+          '29.3.1',
+          winProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a Forge setup on Arm Mac', async () => {
+      const binaryPath = path.join(
+        '/foo',
+        'bar',
+        'out',
+        'my-app-darwin-arm64',
+        'my-app.app',
+        'Contents',
+        'MacOS',
+        'my-app',
+      );
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { packagerConfig: { name: 'my-app' } },
+            isForge: true,
+            isBuilder: false,
+          },
+          '29.3.1',
+          macProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a Forge setup on Intel Mac', async () => {
+      const binaryPath = path.join(
+        '/foo',
+        'bar',
+        'out',
+        'my-app-darwin-x64',
+        'my-app.app',
+        'Contents',
+        'MacOS',
+        'my-app',
+      );
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { packagerConfig: { name: 'my-app' } },
+            isForge: true,
+            isBuilder: false,
+          },
+          '29.3.1',
+          macProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a Forge setup on Linux', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'out', 'my-app-linux-x64', 'my-app');
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { packagerConfig: { name: 'my-app' } },
+            isForge: true,
+            isBuilder: false,
+          },
+          '29.3.1',
+          linuxProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a builder setup with custom output directory', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'custom-outdir', 'win-unpacked', 'my-app.exe');
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { productName: 'my-app', directories: { output: 'custom-outdir' } },
+            isForge: false,
+            isBuilder: true,
+          },
+          '29.3.1',
+          winProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a builder setup on Windows', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'dist', 'win-unpacked', 'my-app.exe');
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { productName: 'my-app' },
+            isForge: false,
+            isBuilder: true,
+          },
+          '29.3.1',
+          winProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a builder setup on Arm Mac', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'dist', 'mac-arm64', 'my-app.app', 'Contents', 'MacOS', 'my-app');
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { productName: 'my-app' },
+            isForge: false,
+            isBuilder: true,
+          },
+          '29.3.1',
+          macProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a builder setup on Intel Mac', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'dist', 'mac', 'my-app.app', 'Contents', 'MacOS', 'my-app');
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { productName: 'my-app' },
+            isForge: false,
+            isBuilder: true,
+          },
+          '29.3.1',
+          macProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a builder setup on Mac (universal arch)', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'dist', 'mac-universal', 'my-app.app', 'Contents', 'MacOS', 'my-app');
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { productName: 'my-app' },
+            isForge: false,
+            isBuilder: true,
+          },
+          '29.3.1',
+          macProcess,
+        ),
+      ).toBe(binaryPath);
+    });
+
+    it('should return the expected app path for a builder setup on Linux', async () => {
+      const binaryPath = path.join('/foo', 'bar', 'dist', 'linux-unpacked', 'my-app');
+      mockBinaryPath(binaryPath);
+      expect(
+        await getBinaryPath(
+          pkgJSONPath,
+          {
+            appName: 'my-app',
+            config: { productName: 'my-app' },
+            isForge: false,
+            isBuilder: true,
+          },
+          '29.3.1',
+          linuxProcess,
+        ),
+      ).toBe(binaryPath);
+    });
   });
 });

--- a/packages/wdio-electron-service/test/capabilities.spec.ts
+++ b/packages/wdio-electron-service/test/capabilities.spec.ts
@@ -8,118 +8,120 @@ type RequestedCapabilities =
   | Capabilities.W3CCapabilities
   | Capabilities.RequestedMultiremoteCapabilities;
 
-describe('getChromeOptions', () => {
-  it('should combine app arguments with chrome options and override the binary path', () => {
-    const options = {
-      appArgs: ['foo=bar'],
-      appBinaryPath: '/path/to/apps',
-    };
-    const cap = {
-      'wdio:chromedriverOptions': {
-        binary: '/path/to/chromdriver',
-      },
-      'goog:chromeOptions': {
-        windowTypes: ['app'],
-        args: ['--no-sandbox'],
-      },
-    };
-    expect(getChromeOptions(options, cap)).toStrictEqual({
-      args: ['--no-sandbox', 'foo=bar'],
-      binary: '/path/to/apps',
-      windowTypes: ['app'],
-    });
-  });
-
-  it('should return default values when app arguments are not provided', () => {
-    const options = {
-      appBinaryPath: '/path/to/apps',
-    };
-    const cap = {
-      'wdio:chromedriverOptions': {
-        binary: '/path/to/chromdriver',
-      },
-    };
-    expect(getChromeOptions(options, cap)).toStrictEqual({
-      args: [],
-      binary: '/path/to/apps',
-      windowTypes: ['app', 'webview'],
-    });
-  });
-});
-
-describe('getChromedriverOptions', () => {
-  it('should return the configured wdio:chromedriverOptions', () => {
-    const expectedOption = {
-      binary: '/path/to/chromdriver',
-    };
-    expect(
-      getChromedriverOptions({
-        'wdio:chromedriverOptions': expectedOption,
-      }),
-    ).toStrictEqual(expectedOption);
-  });
-
-  it('should return an empty object when wdio:chromedriverOptions is absent', () => {
-    expect(
-      getChromedriverOptions({
+describe('Capabilities Utilities', () => {
+  describe('getChromeOptions()', () => {
+    it('should combine app arguments with chrome options and override the binary path', () => {
+      const options = {
+        appArgs: ['foo=bar'],
+        appBinaryPath: '/path/to/apps',
+      };
+      const cap = {
+        'wdio:chromedriverOptions': {
+          binary: '/path/to/chromdriver',
+        },
         'goog:chromeOptions': {
+          windowTypes: ['app'],
           args: ['--no-sandbox'],
         },
-      }),
-    ).toStrictEqual({});
-  });
-});
-
-describe('getElectronCapabilities', () => {
-  const expectedCap = {
-    browserName: 'electron',
-  };
-  describe.each<[string, (browserName: string) => RequestedCapabilities, Array<typeof expectedCap>]>([
-    [
-      'Standard capabilities',
-      (browserName: string): Capabilities.RequestedStandaloneCapabilities => ({
-        browserName,
-      }),
-      [expectedCap],
-    ],
-    [
-      'W3C specific capabilities',
-      (browserName: string): Capabilities.W3CCapabilities => ({
-        alwaysMatch: { browserName },
-        firstMatch: [{}],
-      }),
-      [expectedCap],
-    ],
-    [
-      'Multiremote capabilities',
-      (browserName: string): Capabilities.RequestedMultiremoteCapabilities => ({
-        instanceA: {
-          capabilities: {
-            browserName,
-          },
-        },
-        instanceB: {
-          capabilities: {
-            alwaysMatch: {
-              browserName,
-            },
-            firstMatch: [{}],
-          },
-        },
-      }),
-      [expectedCap, expectedCap],
-    ],
-  ])('%s', (_title, generateCap, expectedCaps) => {
-    it('should return electron capabilities when browserName is "electron"', () => {
-      const cap = generateCap('electron');
-      const caps = getElectronCapabilities(cap);
-      expect(caps).toStrictEqual(expectedCaps);
+      };
+      expect(getChromeOptions(options, cap)).toStrictEqual({
+        args: ['--no-sandbox', 'foo=bar'],
+        binary: '/path/to/apps',
+        windowTypes: ['app'],
+      });
     });
 
-    it('should return an empty array when browserName is not "electron"', () => {
-      const cap = generateCap('chrome');
-      const caps = getElectronCapabilities(cap);
-      expect(caps).toStrictEqual([]);
+    it('should return default values when app arguments are not provided', () => {
+      const options = {
+        appBinaryPath: '/path/to/apps',
+      };
+      const cap = {
+        'wdio:chromedriverOptions': {
+          binary: '/path/to/chromdriver',
+        },
+      };
+      expect(getChromeOptions(options, cap)).toStrictEqual({
+        args: [],
+        binary: '/path/to/apps',
+        windowTypes: ['app', 'webview'],
+      });
+    });
+  });
+
+  describe('getChromedriverOptions()', () => {
+    it('should return the configured wdio:chromedriverOptions', () => {
+      const expectedOption = {
+        binary: '/path/to/chromdriver',
+      };
+      expect(
+        getChromedriverOptions({
+          'wdio:chromedriverOptions': expectedOption,
+        }),
+      ).toStrictEqual(expectedOption);
+    });
+
+    it('should return an empty object when wdio:chromedriverOptions is absent', () => {
+      expect(
+        getChromedriverOptions({
+          'goog:chromeOptions': {
+            args: ['--no-sandbox'],
+          },
+        }),
+      ).toStrictEqual({});
+    });
+  });
+
+  describe('getElectronCapabilities()', () => {
+    const expectedCap = {
+      browserName: 'electron',
+    };
+    describe.each<[string, (browserName: string) => RequestedCapabilities, Array<typeof expectedCap>]>([
+      [
+        'Standard capabilities',
+        (browserName: string): Capabilities.RequestedStandaloneCapabilities => ({
+          browserName,
+        }),
+        [expectedCap],
+      ],
+      [
+        'W3C specific capabilities',
+        (browserName: string): Capabilities.W3CCapabilities => ({
+          alwaysMatch: { browserName },
+          firstMatch: [{}],
+        }),
+        [expectedCap],
+      ],
+      [
+        'Multiremote capabilities',
+        (browserName: string): Capabilities.RequestedMultiremoteCapabilities => ({
+          instanceA: {
+            capabilities: {
+              browserName,
+            },
+          },
+          instanceB: {
+            capabilities: {
+              alwaysMatch: {
+                browserName,
+              },
+              firstMatch: [{}],
+            },
+          },
+        }),
+        [expectedCap, expectedCap],
+      ],
+    ])('%s', (_title, generateCap, expectedCaps) => {
+      it('should return electron capabilities when browserName is "electron"', () => {
+        const cap = generateCap('electron');
+        const caps = getElectronCapabilities(cap);
+        expect(caps).toStrictEqual(expectedCaps);
+      });
+
+      it('should return an empty array when browserName is not "electron"', () => {
+        const cap = generateCap('chrome');
+        const caps = getElectronCapabilities(cap);
+        expect(caps).toStrictEqual([]);
+      });
     });
   });
 });

--- a/packages/wdio-electron-service/test/commands/clearAllMocks.spec.ts
+++ b/packages/wdio-electron-service/test/commands/clearAllMocks.spec.ts
@@ -9,7 +9,7 @@ vi.mock('../../src/mockStore.js', () => ({
   },
 }));
 
-describe('clearAllMocks', () => {
+describe('clearAllMocks Command', () => {
   let mockedGetName, mockedShowOpenDialog;
 
   beforeEach(async () => {

--- a/packages/wdio-electron-service/test/commands/execute.spec.ts
+++ b/packages/wdio-electron-service/test/commands/execute.spec.ts
@@ -2,7 +2,7 @@ import { vi, describe, beforeEach, it, expect } from 'vitest';
 
 import { execute } from '../../src/commands/execute.js';
 
-describe('execute', () => {
+describe('execute Command', () => {
   beforeEach(async () => {
     globalThis.browser = {
       electron: {

--- a/packages/wdio-electron-service/test/commands/isMockFunction.spec.ts
+++ b/packages/wdio-electron-service/test/commands/isMockFunction.spec.ts
@@ -4,7 +4,7 @@ import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
 import { createMock } from '../../src/mock.js';
 import { isMockFunction } from '../../src/commands/isMockFunction.js';
 
-describe('isMockFunction', () => {
+describe('isMockFunction Command', () => {
   beforeEach(async () => {
     globalThis.browser = {
       electron: {

--- a/packages/wdio-electron-service/test/commands/mock.spec.ts
+++ b/packages/wdio-electron-service/test/commands/mock.spec.ts
@@ -23,7 +23,7 @@ afterEach(() => {
   vi.resetModules();
 });
 
-describe('mock', () => {
+describe('mock Command', () => {
   let mockedGetName;
 
   beforeEach(async () => {

--- a/packages/wdio-electron-service/test/commands/mockAll.spec.ts
+++ b/packages/wdio-electron-service/test/commands/mockAll.spec.ts
@@ -3,7 +3,7 @@ import { vi, describe, beforeEach, it, expect, afterEach } from 'vitest';
 
 import { mockAll } from '../../src/commands/mockAll.js';
 
-describe('mockAll', () => {
+describe('mockAll Command', () => {
   beforeEach(async () => {
     globalThis.browser = {
       electron: {

--- a/packages/wdio-electron-service/test/commands/resetAllMocks.spec.ts
+++ b/packages/wdio-electron-service/test/commands/resetAllMocks.spec.ts
@@ -9,7 +9,7 @@ vi.mock('../../src/mockStore.js', () => ({
   },
 }));
 
-describe('resetAllMocks', () => {
+describe('resetAllMocks Command', () => {
   let mockedGetName, mockedShowOpenDialog;
 
   beforeEach(async () => {

--- a/packages/wdio-electron-service/test/commands/restoreAllMocks.spec.ts
+++ b/packages/wdio-electron-service/test/commands/restoreAllMocks.spec.ts
@@ -9,7 +9,7 @@ vi.mock('../../src/mockStore.js', () => ({
   },
 }));
 
-describe('restoreAllMocks', () => {
+describe('restoreAllMocks Command', () => {
   let mockedGetName, mockedShowOpenDialog;
 
   beforeEach(async () => {

--- a/packages/wdio-electron-service/test/launcher.spec.ts
+++ b/packages/wdio-electron-service/test/launcher.spec.ts
@@ -80,552 +80,376 @@ afterEach(() => {
   revertProcessProperty('platform');
 });
 
-describe('onPrepare', () => {
-  beforeEach(() => {
-    instance = new LaunchService(
-      options,
-      [] as never,
-      {
-        services: [['electron', options]],
-      } as Options.Testrunner,
-    );
-  });
-
-  it('should throw an error when there is no electron browser in capabilities', async () => {
-    const capabilities: WebdriverIO.Capabilities[] = [
-      {
-        browserName: 'chrome',
-        browserVersion: '26.2.2',
-      },
-    ];
-    await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
-      'No Electron browser found in capabilities',
-    );
-  });
-
-  describe.each([['esm'], ['cjs']])('%s', (type) => {
-    it('should throw an error when the local Electron version is older than v26 and Chromedriver is not configured manually', async () => {
+describe('Electron Launch Service', () => {
+  describe('onPrepare()', () => {
+    beforeEach(() => {
       instance = new LaunchService(
         options,
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'old-electron'),
         } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
-        'Electron version must be 26 or higher for auto-configuration of Chromedriver.  If you want to use an older version of Electron, you must configure Chromedriver manually using the wdio:chromedriverOptions capability',
       );
     });
 
-    it('should not throw an error when the local Electron version is older than v26 and Chromedriver is configured manually', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'old-electron'),
-        } as Options.Testrunner,
-      );
+    it('should throw an error when there is no electron browser in capabilities', async () => {
       const capabilities: WebdriverIO.Capabilities[] = [
         {
-          'browserName': 'electron',
+          browserName: 'chrome',
+          browserVersion: '26.2.2',
+        },
+      ];
+      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
+        'No Electron browser found in capabilities',
+      );
+    });
+
+    describe.each([['esm'], ['cjs']])('%s', (type) => {
+      it('should throw an error when the local Electron version is older than v26 and Chromedriver is not configured manually', async () => {
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'old-electron'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+          },
+        ];
+        await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
+          'Electron version must be 26 or higher for auto-configuration of Chromedriver.  If you want to use an older version of Electron, you must configure Chromedriver manually using the wdio:chromedriverOptions capability',
+        );
+      });
+
+      it('should not throw an error when the local Electron version is older than v26 and Chromedriver is configured manually', async () => {
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'old-electron'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            'browserName': 'electron',
+            'wdio:chromedriverOptions': {
+              binary: '/path/to/chromedriver',
+            },
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '114.0.5735.45',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
           'wdio:chromedriverOptions': {
             binary: '/path/to/chromedriver',
           },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '114.0.5735.45',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:chromedriverOptions': {
-          binary: '/path/to/chromedriver',
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
       });
-    });
 
-    it('should throw an error when appBinaryPath is not specified and no build tool is found', async () => {
-      delete options.appBinaryPath;
-      (getAppBuildInfo as Mock).mockRejectedValueOnce(new Error('b0rk - no build tool found'));
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          rootDir: getFixtureDir(type, 'no-build-tool'),
-          services: [['electron', options]],
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'browserVersion': '26.2.2',
-          'wdio:electronServiceOptions': {
-            appArgs: ['some', 'args'],
+      it('should throw an error when appBinaryPath is not specified and no build tool is found', async () => {
+        delete options.appBinaryPath;
+        (getAppBuildInfo as Mock).mockRejectedValueOnce(new Error('b0rk - no build tool found'));
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            rootDir: getFixtureDir(type, 'no-build-tool'),
+            services: [['electron', options]],
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            'browserName': 'electron',
+            'browserVersion': '26.2.2',
+            'wdio:electronServiceOptions': {
+              appArgs: ['some', 'args'],
+            },
           },
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow('b0rk - no build tool found');
-    });
-
-    it('should warn when appEntryPoint and appBinaryPath are set', async () => {
-      options.appEntryPoint = './path/to/bundled/electron/main.bundle.js';
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'no-build-tool'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'browserVersion': '26.2.2',
-          'wdio:electronServiceOptions': {
-            appArgs: ['some', 'args'],
-          },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(log.warn).toHaveBeenLastCalledWith(
-        'Both appEntryPoint and appBinaryPath are set, appBinaryPath will be ignored',
-      );
-    });
-
-    it('should throw an error when the detected app path does not exist for a Forge dependency', async () => {
-      delete options.appBinaryPath;
-      (getBinaryPath as Mock).mockRejectedValueOnce(new Error('b0rk'));
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'forge-dependency-inline-config'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'browserVersion': '26.2.2',
-          'wdio:electronServiceOptions': {
-            appArgs: ['some', 'args'],
-          },
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
-        /^Failed setting up Electron session: SevereServiceError: Could not find Electron app at [\S]+ built with Electron Forge!\nIf the application is not compiled, please do so before running your tests, e\.g\. via `npx electron-forge make`\.\nOtherwise if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities\.$/m,
-      );
-    });
-
-    it('should throw an error when the detected app path does not exist for an electron-builder dependency', async () => {
-      delete options.appBinaryPath;
-      (getBinaryPath as Mock).mockRejectedValueOnce(new Error('b0rk'));
-      (getAppBuildInfo as Mock).mockResolvedValueOnce({
-        appName: 'my-test-app',
-        isForge: false,
-        config: {},
+        ];
+        await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
+          'b0rk - no build tool found',
+        );
       });
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'builder-dependency-inline-config'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'browserVersion': '26.2.2',
-          'wdio:electronServiceOptions': {
-            appArgs: ['some', 'args'],
-          },
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
-        /^Failed setting up Electron session: SevereServiceError: Could not find Electron app at [\S]+ built with electron-builder!\nIf the application is not compiled, please do so before running your tests, e\.g\. via `npx electron-builder build`\.\nOtherwise if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities\.$/m,
-      );
-    });
 
-    it('should override global options with capabilities', async () => {
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'browserVersion': '26.2.2',
+      it('should warn when appEntryPoint and appBinaryPath are set', async () => {
+        options.appEntryPoint = './path/to/bundled/electron/main.bundle.js';
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'no-build-tool'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            'browserName': 'electron',
+            'browserVersion': '26.2.2',
+            'wdio:electronServiceOptions': {
+              appArgs: ['some', 'args'],
+            },
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(log.warn).toHaveBeenLastCalledWith(
+          'Both appEntryPoint and appBinaryPath are set, appBinaryPath will be ignored',
+        );
+      });
+
+      it('should throw an error when the detected app path does not exist for a Forge dependency', async () => {
+        delete options.appBinaryPath;
+        (getBinaryPath as Mock).mockRejectedValueOnce(new Error('b0rk'));
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'forge-dependency-inline-config'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            'browserName': 'electron',
+            'browserVersion': '26.2.2',
+            'wdio:electronServiceOptions': {
+              appArgs: ['some', 'args'],
+            },
+          },
+        ];
+        await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
+          /^Failed setting up Electron session: SevereServiceError: Could not find Electron app at [\S]+ built with Electron Forge!\nIf the application is not compiled, please do so before running your tests, e\.g\. via `npx electron-forge make`\.\nOtherwise if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities\.$/m,
+        );
+      });
+
+      it('should throw an error when the detected app path does not exist for an electron-builder dependency', async () => {
+        delete options.appBinaryPath;
+        (getBinaryPath as Mock).mockRejectedValueOnce(new Error('b0rk'));
+        (getAppBuildInfo as Mock).mockResolvedValueOnce({
+          appName: 'my-test-app',
+          isForge: false,
+          config: {},
+        });
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'builder-dependency-inline-config'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            'browserName': 'electron',
+            'browserVersion': '26.2.2',
+            'wdio:electronServiceOptions': {
+              appArgs: ['some', 'args'],
+            },
+          },
+        ];
+        await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
+          /^Failed setting up Electron session: SevereServiceError: Could not find Electron app at [\S]+ built with electron-builder!\nIf the application is not compiled, please do so before running your tests, e\.g\. via `npx electron-builder build`\.\nOtherwise if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities\.$/m,
+        );
+      });
+
+      it('should override global options with capabilities', async () => {
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            'browserName': 'electron',
+            'browserVersion': '26.2.2',
+            'wdio:electronServiceOptions': {
+              appBinaryPath: 'workspace/my-other-test-app/dist/my-other-test-app',
+            },
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.190',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-other-test-app/dist/my-other-test-app',
+            windowTypes: ['app', 'webview'],
+          },
           'wdio:electronServiceOptions': {
             appBinaryPath: 'workspace/my-other-test-app/dist/my-other-test-app',
           },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-other-test-app/dist/my-other-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {
-          appBinaryPath: 'workspace/my-other-test-app/dist/my-other-test-app',
-        },
-        'wdio:enforceWebDriverClassic': true,
+          'wdio:enforceWebDriverClassic': true,
+        });
       });
-    });
 
-    it('should pass through browserVersion', async () => {
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: 'some-version',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': 'some-version',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should use the Electron version from the local package dependencies when browserVersion is not provided', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'electron-in-dependencies'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.82',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should use the Electron version from the nearest package dependencies when browserVersion is not provided', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: path.join(getFixtureDir(type, 'electron-in-dependencies'), 'subpackage', 'subdir'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.82',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should use the Electron version from the local package devDependencies when browserVersion is not provided', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'electron-in-dev-dependencies'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.82',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should use the Electron version from the nearest package devDependencies when browserVersion is not provided', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: path.join(getFixtureDir(type, 'electron-in-dev-dependencies'), 'subpackage', 'subdir'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.82',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should throw an error when browserVersion is not provided and there is no local Electron version', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'no-electron'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
-        'Failed setting up Electron session: Error: You must install Electron locally, or provide a custom Chromedriver path / browserVersion value for each Electron capability',
-      );
-    });
-
-    it('should set the expected capabilities', async () => {
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should apply `--no-sandbox` to the app when appArgs is not set', async () => {
-      delete options.appArgs;
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: ['--no-sandbox'],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should set the expected capabilities when the detected app path exists for a Forge dependency', async () => {
-      delete options.appBinaryPath;
-      (getBinaryPath as Mock).mockResolvedValueOnce('workspace/my-test-app/out/my-test-app');
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'forge-dependency-inline-config'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/out/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should set the expected capabilities when the detected app path exists for an electron-builder dependency', async () => {
-      delete options.appBinaryPath;
-      (getBinaryPath as Mock).mockResolvedValueOnce('workspace/my-test-app/dist/my-test-app');
-      (getAppBuildInfo as Mock).mockResolvedValueOnce({
-        appName: 'my-test-app',
-        isForge: false,
-        config: {},
-      });
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'builder-dependency-inline-config'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should set the expected capabilities when setting appEntryPoint', async () => {
-      delete options.appBinaryPath;
-      options.appEntryPoint = 'path/to/main.bundle.js';
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'no-build-tool'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: ['--app=path/to/main.bundle.js'],
-          binary: path.join(getFixtureDir(type, 'no-build-tool'), 'node_modules', '.bin', 'electron'),
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should set the expected capabilities when setting custom chromedriverOptions', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir(type, 'no-electron'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'wdio:chromedriverOptions': {
-            binary: '/path/to/chromedriver',
+      it('should pass through browserVersion', async () => {
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+            browserVersion: 'some-version',
           },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:chromedriverOptions': {
-          binary: '/path/to/chromedriver',
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': 'some-version',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
       });
-    });
 
-    it('should set the expected capabilities when W3C-specific', async () => {
-      const capabilities: Capabilities.W3CCapabilities[] = [
-        {
-          firstMatch: [],
-          alwaysMatch: {
+      it('should use the Electron version from the local package dependencies when browserVersion is not provided', async () => {
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'electron-in-dependencies'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.82',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should use the Electron version from the nearest package dependencies when browserVersion is not provided', async () => {
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: path.join(getFixtureDir(type, 'electron-in-dependencies'), 'subpackage', 'subdir'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.82',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should use the Electron version from the local package devDependencies when browserVersion is not provided', async () => {
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'electron-in-dev-dependencies'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.82',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should use the Electron version from the nearest package devDependencies when browserVersion is not provided', async () => {
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: path.join(getFixtureDir(type, 'electron-in-dev-dependencies'), 'subpackage', 'subdir'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.82',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should throw an error when browserVersion is not provided and there is no local Electron version', async () => {
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'no-electron'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+          },
+        ];
+        await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
+          'Failed setting up Electron session: Error: You must install Electron locally, or provide a custom Chromedriver path / browserVersion value for each Electron capability',
+        );
+      });
+
+      it('should set the expected capabilities', async () => {
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
             browserName: 'electron',
             browserVersion: '26.2.2',
           },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        firstMatch: [],
-        alwaysMatch: {
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
           'browserName': 'chrome',
           'browserVersion': '116.0.5845.190',
           'goog:chromeOptions': {
@@ -635,49 +459,178 @@ describe('onPrepare', () => {
           },
           'wdio:electronServiceOptions': {},
           'wdio:enforceWebDriverClassic': true,
-        },
+        });
       });
-    });
 
-    it('should set the expected capabilities when multiremote', async () => {
-      const capabilities = {
-        firefox: {
-          capabilities: {
-            browserName: 'firefox',
-          },
-        },
-        myElectronProject: {
-          capabilities: {
+      it('should apply `--no-sandbox` to the app when appArgs is not set', async () => {
+        delete options.appArgs;
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
             browserName: 'electron',
-            browserVersion: '32.0.1',
+            browserVersion: '26.2.2',
           },
-        },
-        chrome: {
-          capabilities: {
-            browserName: 'chrome',
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.190',
+          'goog:chromeOptions': {
+            args: ['--no-sandbox'],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
           },
-        },
-        myOtherElectronProject: {
-          capabilities: {
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should set the expected capabilities when the detected app path exists for a Forge dependency', async () => {
+        delete options.appBinaryPath;
+        (getBinaryPath as Mock).mockResolvedValueOnce('workspace/my-test-app/out/my-test-app');
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'forge-dependency-inline-config'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+            browserVersion: '26.2.2',
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.190',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/out/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should set the expected capabilities when the detected app path exists for an electron-builder dependency', async () => {
+        delete options.appBinaryPath;
+        (getBinaryPath as Mock).mockResolvedValueOnce('workspace/my-test-app/dist/my-test-app');
+        (getAppBuildInfo as Mock).mockResolvedValueOnce({
+          appName: 'my-test-app',
+          isForge: false,
+          config: {},
+        });
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'builder-dependency-inline-config'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+            browserVersion: '26.2.2',
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.190',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should set the expected capabilities when setting appEntryPoint', async () => {
+        delete options.appBinaryPath;
+        options.appEntryPoint = 'path/to/main.bundle.js';
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'no-build-tool'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+            browserVersion: '26.2.2',
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.190',
+          'goog:chromeOptions': {
+            args: ['--app=path/to/main.bundle.js'],
+            binary: path.join(getFixtureDir(type, 'no-build-tool'), 'node_modules', '.bin', 'electron'),
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should set the expected capabilities when setting custom chromedriverOptions', async () => {
+        instance = new LaunchService(
+          options,
+          [] as never,
+          {
+            services: [['electron', options]],
+            rootDir: getFixtureDir(type, 'no-electron'),
+          } as Options.Testrunner,
+        );
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            'browserName': 'electron',
+            'wdio:chromedriverOptions': {
+              binary: '/path/to/chromedriver',
+            },
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          'browserName': 'chrome',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:chromedriverOptions': {
+            binary: '/path/to/chromedriver',
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should set the expected capabilities when W3C-specific', async () => {
+        const capabilities: Capabilities.W3CCapabilities[] = [
+          {
             firstMatch: [],
             alwaysMatch: {
               browserName: 'electron',
               browserVersion: '26.2.2',
             },
           },
-        },
-      };
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities).toEqual({
-        firefox: {
-          capabilities: {
-            browserName: 'firefox',
-          },
-        },
-        myElectronProject: {
-          capabilities: {
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities[0]).toEqual({
+          firstMatch: [],
+          alwaysMatch: {
             'browserName': 'chrome',
-            'browserVersion': '128.0.6613.36',
+            'browserVersion': '116.0.5845.190',
             'goog:chromeOptions': {
               args: [],
               binary: 'workspace/my-test-app/dist/my-test-app',
@@ -686,34 +639,11 @@ describe('onPrepare', () => {
             'wdio:electronServiceOptions': {},
             'wdio:enforceWebDriverClassic': true,
           },
-        },
-        chrome: {
-          capabilities: {
-            browserName: 'chrome',
-          },
-        },
-        myOtherElectronProject: {
-          capabilities: {
-            firstMatch: [],
-            alwaysMatch: {
-              'browserName': 'chrome',
-              'browserVersion': '116.0.5845.190',
-              'goog:chromeOptions': {
-                args: [],
-                binary: 'workspace/my-test-app/dist/my-test-app',
-                windowTypes: ['app', 'webview'],
-              },
-              'wdio:electronServiceOptions': {},
-              'wdio:enforceWebDriverClassic': true,
-            },
-          },
-        },
+        });
       });
-    });
 
-    it('should set the expected capabilities when parallel multiremote', async () => {
-      const capabilities: Capabilities.RequestedMultiremoteCapabilities[] = [
-        {
+      it('should set the expected capabilities when multiremote', async () => {
+        const capabilities = {
           firefox: {
             capabilities: {
               browserName: 'firefox',
@@ -725,8 +655,6 @@ describe('onPrepare', () => {
               browserVersion: '32.0.1',
             },
           },
-        },
-        {
           chrome: {
             capabilities: {
               browserName: 'chrome',
@@ -741,11 +669,9 @@ describe('onPrepare', () => {
               },
             },
           },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities).toEqual([
-        {
+        };
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities).toEqual({
           firefox: {
             capabilities: {
               browserName: 'firefox',
@@ -764,8 +690,6 @@ describe('onPrepare', () => {
               'wdio:enforceWebDriverClassic': true,
             },
           },
-        },
-        {
           chrome: {
             capabilities: {
               browserName: 'chrome',
@@ -787,8 +711,88 @@ describe('onPrepare', () => {
               },
             },
           },
-        },
-      ]);
+        });
+      });
+
+      it('should set the expected capabilities when parallel multiremote', async () => {
+        const capabilities: Capabilities.RequestedMultiremoteCapabilities[] = [
+          {
+            firefox: {
+              capabilities: {
+                browserName: 'firefox',
+              },
+            },
+            myElectronProject: {
+              capabilities: {
+                browserName: 'electron',
+                browserVersion: '32.0.1',
+              },
+            },
+          },
+          {
+            chrome: {
+              capabilities: {
+                browserName: 'chrome',
+              },
+            },
+            myOtherElectronProject: {
+              capabilities: {
+                firstMatch: [],
+                alwaysMatch: {
+                  browserName: 'electron',
+                  browserVersion: '26.2.2',
+                },
+              },
+            },
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(capabilities).toEqual([
+          {
+            firefox: {
+              capabilities: {
+                browserName: 'firefox',
+              },
+            },
+            myElectronProject: {
+              capabilities: {
+                'browserName': 'chrome',
+                'browserVersion': '128.0.6613.36',
+                'goog:chromeOptions': {
+                  args: [],
+                  binary: 'workspace/my-test-app/dist/my-test-app',
+                  windowTypes: ['app', 'webview'],
+                },
+                'wdio:electronServiceOptions': {},
+                'wdio:enforceWebDriverClassic': true,
+              },
+            },
+          },
+          {
+            chrome: {
+              capabilities: {
+                browserName: 'chrome',
+              },
+            },
+            myOtherElectronProject: {
+              capabilities: {
+                firstMatch: [],
+                alwaysMatch: {
+                  'browserName': 'chrome',
+                  'browserVersion': '116.0.5845.190',
+                  'goog:chromeOptions': {
+                    args: [],
+                    binary: 'workspace/my-test-app/dist/my-test-app',
+                    windowTypes: ['app', 'webview'],
+                  },
+                  'wdio:electronServiceOptions': {},
+                  'wdio:enforceWebDriverClassic': true,
+                },
+              },
+            },
+          },
+        ]);
+      });
     });
   });
 });

--- a/packages/wdio-electron-service/test/launcher.spec.ts
+++ b/packages/wdio-electron-service/test/launcher.spec.ts
@@ -36,6 +36,15 @@ vi.mock('@wdio/electron-utils', async (importOriginal: () => Promise<Record<stri
   };
 });
 
+vi.mock('@wdio/electron-utils/log', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 beforeEach(async () => {
   mockProcessProperty('platform', 'darwin');
   LaunchService = (await import('../src/launcher.js')).default;
@@ -93,14 +102,14 @@ describe('onPrepare', () => {
     );
   });
 
-  describe('ESM', () => {
+  describe.each([['esm'], ['cjs']])('%s', (type) => {
     it('should throw an error when the local Electron version is older than v26 and Chromedriver is not configured manually', async () => {
       instance = new LaunchService(
         options,
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'old-electron'),
+          rootDir: getFixtureDir(type, 'old-electron'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -119,7 +128,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'old-electron'),
+          rootDir: getFixtureDir(type, 'old-electron'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -154,7 +163,7 @@ describe('onPrepare', () => {
         options,
         [] as never,
         {
-          rootDir: getFixtureDir('esm', 'no-build-tool'),
+          rootDir: getFixtureDir(type, 'no-build-tool'),
           services: [['electron', options]],
         } as Options.Testrunner,
       );
@@ -178,7 +187,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'forge-dependency-inline-config'),
+          rootDir: getFixtureDir(type, 'forge-dependency-inline-config'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -208,7 +217,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'builder-dependency-inline-config'),
+          rootDir: getFixtureDir(type, 'builder-dependency-inline-config'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -278,7 +287,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'electron-in-dependencies'),
+          rootDir: getFixtureDir(type, 'electron-in-dependencies'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -306,7 +315,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: path.join(getFixtureDir('esm', 'electron-in-dependencies'), 'subpackage', 'subdir'),
+          rootDir: path.join(getFixtureDir(type, 'electron-in-dependencies'), 'subpackage', 'subdir'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -334,7 +343,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'electron-in-dev-dependencies'),
+          rootDir: getFixtureDir(type, 'electron-in-dev-dependencies'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -362,7 +371,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: path.join(getFixtureDir('esm', 'electron-in-dev-dependencies'), 'subpackage', 'subdir'),
+          rootDir: path.join(getFixtureDir(type, 'electron-in-dev-dependencies'), 'subpackage', 'subdir'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -390,7 +399,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'no-electron'),
+          rootDir: getFixtureDir(type, 'no-electron'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -454,7 +463,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'forge-dependency-inline-config'),
+          rootDir: getFixtureDir(type, 'forge-dependency-inline-config'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -490,7 +499,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'builder-dependency-inline-config'),
+          rootDir: getFixtureDir(type, 'builder-dependency-inline-config'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -521,7 +530,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'no-build-tool'),
+          rootDir: getFixtureDir(type, 'no-build-tool'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [
@@ -536,7 +545,7 @@ describe('onPrepare', () => {
         'browserVersion': '116.0.5845.190',
         'goog:chromeOptions': {
           args: ['--app=path/to/main.bundle.js'],
-          binary: path.join(getFixtureDir('esm', 'no-build-tool'), 'node_modules', '.bin', 'electron'),
+          binary: path.join(getFixtureDir(type, 'no-build-tool'), 'node_modules', '.bin', 'electron'),
           windowTypes: ['app', 'webview'],
         },
         'wdio:electronServiceOptions': {},
@@ -550,671 +559,7 @@ describe('onPrepare', () => {
         [] as never,
         {
           services: [['electron', options]],
-          rootDir: getFixtureDir('esm', 'no-electron'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'wdio:chromedriverOptions': {
-            binary: '/path/to/chromedriver',
-          },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:chromedriverOptions': {
-          binary: '/path/to/chromedriver',
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should set the expected capabilities when W3C-specific', async () => {
-      const capabilities: Capabilities.W3CCapabilities[] = [
-        {
-          firstMatch: [],
-          alwaysMatch: {
-            browserName: 'electron',
-            browserVersion: '26.2.2',
-          },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        firstMatch: [],
-        alwaysMatch: {
-          'browserName': 'chrome',
-          'browserVersion': '116.0.5845.190',
-          'goog:chromeOptions': {
-            args: [],
-            binary: 'workspace/my-test-app/dist/my-test-app',
-            windowTypes: ['app', 'webview'],
-          },
-          'wdio:electronServiceOptions': {},
-          'wdio:enforceWebDriverClassic': true,
-        },
-      });
-    });
-
-    it('should set the expected capabilities when multiremote', async () => {
-      const capabilities = {
-        firefox: {
-          capabilities: {
-            browserName: 'firefox',
-          },
-        },
-        myElectronProject: {
-          capabilities: {
-            browserName: 'electron',
-            browserVersion: '32.0.1',
-          },
-        },
-        chrome: {
-          capabilities: {
-            browserName: 'chrome',
-          },
-        },
-        myOtherElectronProject: {
-          capabilities: {
-            firstMatch: [],
-            alwaysMatch: {
-              browserName: 'electron',
-              browserVersion: '26.2.2',
-            },
-          },
-        },
-      };
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities).toEqual({
-        firefox: {
-          capabilities: {
-            browserName: 'firefox',
-          },
-        },
-        myElectronProject: {
-          capabilities: {
-            'browserName': 'chrome',
-            'browserVersion': '128.0.6613.36',
-            'goog:chromeOptions': {
-              args: [],
-              binary: 'workspace/my-test-app/dist/my-test-app',
-              windowTypes: ['app', 'webview'],
-            },
-            'wdio:electronServiceOptions': {},
-            'wdio:enforceWebDriverClassic': true,
-          },
-        },
-        chrome: {
-          capabilities: {
-            browserName: 'chrome',
-          },
-        },
-        myOtherElectronProject: {
-          capabilities: {
-            firstMatch: [],
-            alwaysMatch: {
-              'browserName': 'chrome',
-              'browserVersion': '116.0.5845.190',
-              'goog:chromeOptions': {
-                args: [],
-                binary: 'workspace/my-test-app/dist/my-test-app',
-                windowTypes: ['app', 'webview'],
-              },
-              'wdio:electronServiceOptions': {},
-              'wdio:enforceWebDriverClassic': true,
-            },
-          },
-        },
-      });
-    });
-
-    it('should set the expected capabilities when parallel multiremote', async () => {
-      const capabilities: Capabilities.RequestedMultiremoteCapabilities[] = [
-        {
-          firefox: {
-            capabilities: {
-              browserName: 'firefox',
-            },
-          },
-          myElectronProject: {
-            capabilities: {
-              browserName: 'electron',
-              browserVersion: '32.0.1',
-            },
-          },
-        },
-        {
-          chrome: {
-            capabilities: {
-              browserName: 'chrome',
-            },
-          },
-          myOtherElectronProject: {
-            capabilities: {
-              firstMatch: [],
-              alwaysMatch: {
-                browserName: 'electron',
-                browserVersion: '26.2.2',
-              },
-            },
-          },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities).toEqual([
-        {
-          firefox: {
-            capabilities: {
-              browserName: 'firefox',
-            },
-          },
-          myElectronProject: {
-            capabilities: {
-              'browserName': 'chrome',
-              'browserVersion': '128.0.6613.36',
-              'goog:chromeOptions': {
-                args: [],
-                binary: 'workspace/my-test-app/dist/my-test-app',
-                windowTypes: ['app', 'webview'],
-              },
-              'wdio:electronServiceOptions': {},
-              'wdio:enforceWebDriverClassic': true,
-            },
-          },
-        },
-        {
-          chrome: {
-            capabilities: {
-              browserName: 'chrome',
-            },
-          },
-          myOtherElectronProject: {
-            capabilities: {
-              firstMatch: [],
-              alwaysMatch: {
-                'browserName': 'chrome',
-                'browserVersion': '116.0.5845.190',
-                'goog:chromeOptions': {
-                  args: [],
-                  binary: 'workspace/my-test-app/dist/my-test-app',
-                  windowTypes: ['app', 'webview'],
-                },
-                'wdio:electronServiceOptions': {},
-                'wdio:enforceWebDriverClassic': true,
-              },
-            },
-          },
-        },
-      ]);
-    });
-  });
-
-  describe('CJS', () => {
-    it('should throw an error when the local Electron version is older than v26 and Chromedriver is not configured manually', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'old-electron'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
-        'Electron version must be 26 or higher for auto-configuration of Chromedriver.  If you want to use an older version of Electron, you must configure Chromedriver manually using the wdio:chromedriverOptions capability',
-      );
-    });
-
-    it('should not throw an error when the local Electron version is older than v26 and Chromedriver is configured manually', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'old-electron'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'wdio:chromedriverOptions': {
-            binary: '/path/to/chromedriver',
-          },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '114.0.5735.45',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:chromedriverOptions': {
-          binary: '/path/to/chromedriver',
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should throw an error when appBinaryPath is not specified and no build tool is found', async () => {
-      delete options.appBinaryPath;
-      (getAppBuildInfo as Mock).mockRejectedValueOnce(new Error('b0rk - no build tool found'));
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          rootDir: getFixtureDir('cjs', 'no-build-tool'),
-          services: [['electron', options]],
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'browserVersion': '26.2.2',
-          'wdio:electronServiceOptions': {
-            appArgs: ['some', 'args'],
-          },
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow('b0rk - no build tool found');
-    });
-
-    it('should throw an error when the detected app path does not exist for a Forge dependency', async () => {
-      delete options.appBinaryPath;
-      (getBinaryPath as Mock).mockRejectedValueOnce(new Error('b0rk'));
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'forge-dependency-inline-config'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'browserVersion': '26.2.2',
-          'wdio:electronServiceOptions': {
-            appArgs: ['some', 'args'],
-          },
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
-        /^Failed setting up Electron session: SevereServiceError: Could not find Electron app at [\S]+ built with Electron Forge!\nIf the application is not compiled, please do so before running your tests, e\.g\. via `npx electron-forge make`\.\nOtherwise if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities\.$/m,
-      );
-    });
-
-    it('should throw an error when the detected app path does not exist for an electron-builder dependency', async () => {
-      delete options.appBinaryPath;
-      (getBinaryPath as Mock).mockRejectedValueOnce(new Error('b0rk'));
-      (getAppBuildInfo as Mock).mockResolvedValueOnce({
-        appName: 'my-test-app',
-        isForge: false,
-        config: {},
-      });
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'builder-dependency-inline-config'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'browserVersion': '26.2.2',
-          'wdio:electronServiceOptions': {
-            appArgs: ['some', 'args'],
-          },
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
-        /^Failed setting up Electron session: SevereServiceError: Could not find Electron app at [\S]+ built with electron-builder!\nIf the application is not compiled, please do so before running your tests, e\.g\. via `npx electron-builder build`\.\nOtherwise if the application is compiled at a different location, please specify the `appBinaryPath` option in your capabilities\.$/m,
-      );
-    });
-
-    it('should override global options with capabilities', async () => {
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          'browserName': 'electron',
-          'browserVersion': '26.2.2',
-          'wdio:electronServiceOptions': {
-            appBinaryPath: 'workspace/my-other-test-app/dist/my-other-test-app',
-          },
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-other-test-app/dist/my-other-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {
-          appBinaryPath: 'workspace/my-other-test-app/dist/my-other-test-app',
-        },
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should pass through browserVersion', async () => {
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: 'some-version',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': 'some-version',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should use the Electron version from the local package dependencies when browserVersion is not provided', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'electron-in-dependencies'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.82',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should use the Electron version from the nearest package dependencies when browserVersion is not provided', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: path.join(getFixtureDir('cjs', 'electron-in-dependencies'), 'subpackage', 'subdir'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.82',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should use the Electron version from the local package devDependencies when browserVersion is not provided', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'electron-in-dev-dependencies'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.82',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should use the Electron version from the nearest package devDependencies when browserVersion is not provided', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: path.join(getFixtureDir('cjs', 'electron-in-dev-dependencies'), 'subpackage', 'subdir'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.82',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should throw an error when browserVersion is not provided and there is no local Electron version', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'no-electron'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-        },
-      ];
-      await expect(() => instance?.onPrepare({} as never, capabilities)).rejects.toThrow(
-        'Failed setting up Electron session: Error: You must install Electron locally, or provide a custom Chromedriver path / browserVersion value for each Electron capability',
-      );
-    });
-
-    it('should set the expected capabilities', async () => {
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should apply `--no-sandbox` to the app when appArgs is not set', async () => {
-      delete options.appArgs;
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: ['--no-sandbox'],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should set the expected capabilities when the detected app path exists for a Forge dependency', async () => {
-      delete options.appBinaryPath;
-      (getBinaryPath as Mock).mockResolvedValueOnce('workspace/my-test-app/out/my-test-app');
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'forge-dependency-inline-config'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/out/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should set the expected capabilities when the detected app path exists for an electron-builder dependency', async () => {
-      delete options.appBinaryPath;
-      (getBinaryPath as Mock).mockResolvedValueOnce('workspace/my-test-app/dist/my-test-app');
-      (getAppBuildInfo as Mock).mockResolvedValueOnce({
-        appName: 'my-test-app',
-        isForge: false,
-        config: {},
-      });
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'builder-dependency-inline-config'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: [],
-          binary: 'workspace/my-test-app/dist/my-test-app',
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should set the expected capabilities when setting appEntryPoint', async () => {
-      delete options.appBinaryPath;
-      options.appEntryPoint = 'path/to/main.bundle.js';
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'no-build-tool'),
-        } as Options.Testrunner,
-      );
-      const capabilities: WebdriverIO.Capabilities[] = [
-        {
-          browserName: 'electron',
-          browserVersion: '26.2.2',
-        },
-      ];
-      await instance?.onPrepare({} as never, capabilities);
-      expect(capabilities[0]).toEqual({
-        'browserName': 'chrome',
-        'browserVersion': '116.0.5845.190',
-        'goog:chromeOptions': {
-          args: ['--app=path/to/main.bundle.js'],
-          binary: path.join(getFixtureDir('cjs', 'no-build-tool'), 'node_modules', '.bin', 'electron'),
-          windowTypes: ['app', 'webview'],
-        },
-        'wdio:electronServiceOptions': {},
-        'wdio:enforceWebDriverClassic': true,
-      });
-    });
-
-    it('should set the expected capabilities when setting custom chromedriverOptions', async () => {
-      instance = new LaunchService(
-        options,
-        [] as never,
-        {
-          services: [['electron', options]],
-          rootDir: getFixtureDir('cjs', 'no-electron'),
+          rootDir: getFixtureDir(type, 'no-electron'),
         } as Options.Testrunner,
       );
       const capabilities: WebdriverIO.Capabilities[] = [

--- a/packages/wdio-electron-service/test/main.spec.ts
+++ b/packages/wdio-electron-service/test/main.spec.ts
@@ -1,4 +1,4 @@
-import { vi, beforeEach, afterEach, it, expect } from 'vitest';
+import { vi, beforeEach, afterEach, it, expect, describe } from 'vitest';
 import { IpcMainInvokeEvent } from 'electron';
 
 const ipcMain = {
@@ -30,16 +30,18 @@ afterEach(() => {
   listeners = {};
 });
 
-it('should call ipcMain.handle with the expected parameters', () => {
-  expect(ipcMain.handle.mock.calls).toEqual([['wdio-electron.execute', expect.any(Function)]]);
-});
+describe('Main Process Integration', () => {
+  it('should call ipcMain.handle with the expected parameters', () => {
+    expect(ipcMain.handle.mock.calls).toEqual([['wdio-electron.execute', expect.any(Function)]]);
+  });
 
-it('should execute a script', () => {
-  expect(
-    ipcMain.handle.mock.calls[0][1](
-      undefined,
-      (electron: typeof electronMock, a: number, b: number, c: number) => electron.app.getName() + a + b + c,
-      [1, 2, 3],
-    ),
-  ).toBe('test123');
+  it('should execute a script', () => {
+    expect(
+      ipcMain.handle.mock.calls[0][1](
+        undefined,
+        (electron: typeof electronMock, a: number, b: number, c: number) => electron.app.getName() + a + b + c,
+        [1, 2, 3],
+      ),
+    ).toBe('test123');
+  });
 });

--- a/packages/wdio-electron-service/test/mock.spec.ts
+++ b/packages/wdio-electron-service/test/mock.spec.ts
@@ -66,322 +66,324 @@ beforeEach(() => {
   } as unknown as WebdriverIO.Browser;
 });
 
-describe('createMock', () => {
-  it('should create a mock with the expected name', async () => {
-    const mock = await createMock('app', 'getName');
+describe('Mock API', () => {
+  describe('createMock()', () => {
+    it('should create a mock with the expected name', async () => {
+      const mock = await createMock('app', 'getName');
 
-    expect(mock.getMockName()).toBe('electron.app.getName');
-  });
+      expect(mock.getMockName()).toBe('electron.app.getName');
+    });
 
-  it('should create a mock with the expected methods', async () => {
-    const mock = await createMock('app', 'getName');
+    it('should create a mock with the expected methods', async () => {
+      const mock = await createMock('app', 'getName');
 
-    expect(mock.mockImplementation).toStrictEqual(expect.any(Function));
-    expect(mock.mockImplementationOnce).toStrictEqual(expect.any(Function));
-    expect(mock.mockReturnValue).toStrictEqual(expect.any(Function));
-    expect(mock.mockReturnValueOnce).toStrictEqual(expect.any(Function));
-    expect(mock.mockResolvedValue).toStrictEqual(expect.any(Function));
-    expect(mock.mockResolvedValueOnce).toStrictEqual(expect.any(Function));
-    expect(mock.mockRejectedValue).toStrictEqual(expect.any(Function));
-    expect(mock.mockRejectedValueOnce).toStrictEqual(expect.any(Function));
-    expect(mock.mockClear).toStrictEqual(expect.any(Function));
-    expect(mock.mockReset).toStrictEqual(expect.any(Function));
-    expect(mock.mockRestore).toStrictEqual(expect.any(Function));
-    expect(mock.update).toStrictEqual(expect.any(Function));
-  });
+      expect(mock.mockImplementation).toStrictEqual(expect.any(Function));
+      expect(mock.mockImplementationOnce).toStrictEqual(expect.any(Function));
+      expect(mock.mockReturnValue).toStrictEqual(expect.any(Function));
+      expect(mock.mockReturnValueOnce).toStrictEqual(expect.any(Function));
+      expect(mock.mockResolvedValue).toStrictEqual(expect.any(Function));
+      expect(mock.mockResolvedValueOnce).toStrictEqual(expect.any(Function));
+      expect(mock.mockRejectedValue).toStrictEqual(expect.any(Function));
+      expect(mock.mockRejectedValueOnce).toStrictEqual(expect.any(Function));
+      expect(mock.mockClear).toStrictEqual(expect.any(Function));
+      expect(mock.mockReset).toStrictEqual(expect.any(Function));
+      expect(mock.mockRestore).toStrictEqual(expect.any(Function));
+      expect(mock.update).toStrictEqual(expect.any(Function));
+    });
 
-  it('should initialise the inner mock', async () => {
-    await createMock('app', 'getName');
-    const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
-    await processExecuteCalls(electron);
+    it('should initialise the inner mock', async () => {
+      await createMock('app', 'getName');
+      const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
+      await processExecuteCalls(electron);
 
-    expect(electron.app.getName).toStrictEqual(expect.anyMockFunction());
-  });
+      expect(electron.app.getName).toStrictEqual(expect.anyMockFunction());
+    });
 
-  describe('update', () => {
-    it('should update according to the status of the inner mock', async () => {
-      const mock = await createMock('app', 'getFileIcon');
-      mockExecute.mockImplementation((fn, apiName, funcName) => {
-        return fn(
-          {
-            app: {
-              getFileIcon: {
-                mock: {
-                  calls: [['/path/to/another/icon', { size: 'small' }]],
+    describe('update', () => {
+      it('should update according to the status of the inner mock', async () => {
+        const mock = await createMock('app', 'getFileIcon');
+        mockExecute.mockImplementation((fn, apiName, funcName) => {
+          return fn(
+            {
+              app: {
+                getFileIcon: {
+                  mock: {
+                    calls: [['/path/to/another/icon', { size: 'small' }]],
+                  },
                 },
               },
             },
-          },
-          apiName,
-          funcName,
-        );
+            apiName,
+            funcName,
+          );
+        });
+        await mock.update();
+        const returnedMock = mock as unknown as Mock;
+
+        expect(returnedMock).toHaveBeenCalledTimes(1);
+        expect(returnedMock).toHaveBeenCalledWith('/path/to/another/icon', { size: 'small' });
       });
-      await mock.update();
-      const returnedMock = mock as unknown as Mock;
 
-      expect(returnedMock).toHaveBeenCalledTimes(1);
-      expect(returnedMock).toHaveBeenCalledWith('/path/to/another/icon', { size: 'small' });
-    });
-
-    it('should update according to the empty calls', async () => {
-      const mock = await createMock('app', 'getFileIcon');
-      mockExecute.mockImplementation((fn, apiName, funcName) => {
-        return fn(
-          {
-            app: {
-              getFileIcon: {},
+      it('should update according to the empty calls', async () => {
+        const mock = await createMock('app', 'getFileIcon');
+        mockExecute.mockImplementation((fn, apiName, funcName) => {
+          return fn(
+            {
+              app: {
+                getFileIcon: {},
+              },
             },
-          },
-          apiName,
-          funcName,
+            apiName,
+            funcName,
+          );
+        });
+        await mock.update();
+        const returnedMock = mock as unknown as Mock;
+
+        expect(returnedMock).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('mockImplementation', () => {
+      it('should set mockImplementation of the inner mock', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
+        await processExecuteCalls(electron);
+        await mock.mockImplementation(() => 'mock implementation');
+        await processExecuteCalls(electron);
+
+        expect(electron.app.getName()).toBe('mock implementation');
+      });
+    });
+
+    describe('mockImplementationOnce', () => {
+      it('should set mockImplementationOnce of the inner mock', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
+        await processExecuteCalls(electron);
+        await mock.mockImplementation(() => 'default mock implementation');
+        await mock.mockImplementationOnce(() => 'first mock implementation');
+        await mock.mockImplementationOnce(() => 'second mock implementation');
+        await processExecuteCalls(electron);
+
+        expect(electron.app.getName()).toBe('first mock implementation');
+        expect(electron.app.getName()).toBe('second mock implementation');
+        expect(electron.app.getName()).toBe('default mock implementation');
+        expect(electron.app.getName()).toBe('default mock implementation');
+      });
+    });
+
+    describe('mockReturnValue', () => {
+      it('should set mockReturnValue of the inner mock', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
+        await processExecuteCalls(electron);
+        await mock.mockReturnValue('mock return value');
+        await processExecuteCalls(electron);
+
+        expect(electron.app.getName()).toBe('mock return value');
+      });
+    });
+
+    describe('mockReturnValueOnce', () => {
+      it('should set mockReturnValueOnce of the inner mock', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
+        await processExecuteCalls(electron);
+        await mock.mockReturnValue('default mock return value');
+        await mock.mockReturnValueOnce('first mock return value');
+        await mock.mockReturnValueOnce('second mock return value');
+        await processExecuteCalls(electron);
+
+        expect(electron.app.getName()).toBe('first mock return value');
+        expect(electron.app.getName()).toBe('second mock return value');
+        expect(electron.app.getName()).toBe('default mock return value');
+      });
+    });
+
+    describe('mockResolvedValue', () => {
+      it('should set mockResolvedValue of the inner mock', async () => {
+        const mock = await createMock('app', 'getFileIcon');
+        const electron = {
+          app: { getFileIcon: () => Promise.resolve('actual fileIcon') } as unknown as Omit<ElectronType['app'], 'on'>,
+        };
+        await processExecuteCalls(electron);
+        await mock.mockResolvedValue('mock resolved value');
+        await processExecuteCalls(electron);
+
+        expect(await electron.app.getFileIcon('/path/to/icon')).toBe('mock resolved value');
+      });
+    });
+
+    describe('mockResolvedValueOnce', () => {
+      it('should set mockResolvedValueOnce of the inner mock', async () => {
+        const mock = await createMock('app', 'getFileIcon');
+        const electron = {
+          app: { getFileIcon: () => Promise.resolve('actual fileIcon') } as unknown as Omit<ElectronType['app'], 'on'>,
+        };
+        await processExecuteCalls(electron);
+        await mock.mockResolvedValue('default mock resolved value');
+        await mock.mockResolvedValueOnce('first mock resolved value');
+        await mock.mockResolvedValueOnce('second mock resolved value');
+        await processExecuteCalls(electron);
+
+        expect(await electron.app.getFileIcon('/path/to/icon')).toBe('first mock resolved value');
+        expect(await electron.app.getFileIcon('/path/to/icon')).toBe('second mock resolved value');
+        expect(await electron.app.getFileIcon('/path/to/icon')).toBe('default mock resolved value');
+      });
+    });
+
+    describe('mockRejectedValue', () => {
+      it('should set mockRejectedValue of the inner mock', async () => {
+        const mock = await createMock('app', 'getFileIcon');
+        const electron = {
+          app: { getFileIcon: () => Promise.resolve('actual fileIcon') } as unknown as Omit<ElectronType['app'], 'on'>,
+        };
+        await processExecuteCalls(electron);
+        await mock.mockRejectedValue('mock rejected value');
+        await processExecuteCalls(electron);
+
+        await expect(() => electron.app.getFileIcon('/path/to/icon')).rejects.toThrow('mock rejected value');
+      });
+    });
+
+    describe('mockRejectedValueOnce', () => {
+      it('should set mockRejectedValueOnce of the inner mock', async () => {
+        const mock = await createMock('app', 'getFileIcon');
+        const electron = {
+          app: { getFileIcon: () => Promise.resolve('actual fileIcon') } as unknown as Omit<ElectronType['app'], 'on'>,
+        };
+        await processExecuteCalls(electron);
+        await mock.mockRejectedValue('default mock rejected value');
+        await mock.mockRejectedValueOnce('first mock rejected value');
+        await mock.mockRejectedValueOnce('second mock rejected value');
+        await processExecuteCalls(electron);
+
+        await expect(async () => await electron.app.getFileIcon('/path/to/icon')).rejects.toThrow(
+          'first mock rejected value',
+        );
+        await expect(async () => await electron.app.getFileIcon('/path/to/icon')).rejects.toThrow(
+          'second mock rejected value',
+        );
+        await expect(async () => await electron.app.getFileIcon('/path/to/icon')).rejects.toThrow(
+          'default mock rejected value',
         );
       });
-      await mock.update();
-      const returnedMock = mock as unknown as Mock;
-
-      expect(returnedMock).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('mockImplementation', () => {
-    it('should set mockImplementation of the inner mock', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
-      await processExecuteCalls(electron);
-      await mock.mockImplementation(() => 'mock implementation');
-      await processExecuteCalls(electron);
-
-      expect(electron.app.getName()).toBe('mock implementation');
-    });
-  });
-
-  describe('mockImplementationOnce', () => {
-    it('should set mockImplementationOnce of the inner mock', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
-      await processExecuteCalls(electron);
-      await mock.mockImplementation(() => 'default mock implementation');
-      await mock.mockImplementationOnce(() => 'first mock implementation');
-      await mock.mockImplementationOnce(() => 'second mock implementation');
-      await processExecuteCalls(electron);
-
-      expect(electron.app.getName()).toBe('first mock implementation');
-      expect(electron.app.getName()).toBe('second mock implementation');
-      expect(electron.app.getName()).toBe('default mock implementation');
-      expect(electron.app.getName()).toBe('default mock implementation');
-    });
-  });
-
-  describe('mockReturnValue', () => {
-    it('should set mockReturnValue of the inner mock', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
-      await processExecuteCalls(electron);
-      await mock.mockReturnValue('mock return value');
-      await processExecuteCalls(electron);
-
-      expect(electron.app.getName()).toBe('mock return value');
-    });
-  });
-
-  describe('mockReturnValueOnce', () => {
-    it('should set mockReturnValueOnce of the inner mock', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = { app: { getName: () => 'actual name' } as Omit<ElectronType['app'], 'on'> };
-      await processExecuteCalls(electron);
-      await mock.mockReturnValue('default mock return value');
-      await mock.mockReturnValueOnce('first mock return value');
-      await mock.mockReturnValueOnce('second mock return value');
-      await processExecuteCalls(electron);
-
-      expect(electron.app.getName()).toBe('first mock return value');
-      expect(electron.app.getName()).toBe('second mock return value');
-      expect(electron.app.getName()).toBe('default mock return value');
-    });
-  });
-
-  describe('mockResolvedValue', () => {
-    it('should set mockResolvedValue of the inner mock', async () => {
-      const mock = await createMock('app', 'getFileIcon');
-      const electron = {
-        app: { getFileIcon: () => Promise.resolve('actual fileIcon') } as unknown as Omit<ElectronType['app'], 'on'>,
-      };
-      await processExecuteCalls(electron);
-      await mock.mockResolvedValue('mock resolved value');
-      await processExecuteCalls(electron);
-
-      expect(await electron.app.getFileIcon('/path/to/icon')).toBe('mock resolved value');
-    });
-  });
-
-  describe('mockResolvedValueOnce', () => {
-    it('should set mockResolvedValueOnce of the inner mock', async () => {
-      const mock = await createMock('app', 'getFileIcon');
-      const electron = {
-        app: { getFileIcon: () => Promise.resolve('actual fileIcon') } as unknown as Omit<ElectronType['app'], 'on'>,
-      };
-      await processExecuteCalls(electron);
-      await mock.mockResolvedValue('default mock resolved value');
-      await mock.mockResolvedValueOnce('first mock resolved value');
-      await mock.mockResolvedValueOnce('second mock resolved value');
-      await processExecuteCalls(electron);
-
-      expect(await electron.app.getFileIcon('/path/to/icon')).toBe('first mock resolved value');
-      expect(await electron.app.getFileIcon('/path/to/icon')).toBe('second mock resolved value');
-      expect(await electron.app.getFileIcon('/path/to/icon')).toBe('default mock resolved value');
-    });
-  });
-
-  describe('mockRejectedValue', () => {
-    it('should set mockRejectedValue of the inner mock', async () => {
-      const mock = await createMock('app', 'getFileIcon');
-      const electron = {
-        app: { getFileIcon: () => Promise.resolve('actual fileIcon') } as unknown as Omit<ElectronType['app'], 'on'>,
-      };
-      await processExecuteCalls(electron);
-      await mock.mockRejectedValue('mock rejected value');
-      await processExecuteCalls(electron);
-
-      await expect(() => electron.app.getFileIcon('/path/to/icon')).rejects.toThrow('mock rejected value');
-    });
-  });
-
-  describe('mockRejectedValueOnce', () => {
-    it('should set mockRejectedValueOnce of the inner mock', async () => {
-      const mock = await createMock('app', 'getFileIcon');
-      const electron = {
-        app: { getFileIcon: () => Promise.resolve('actual fileIcon') } as unknown as Omit<ElectronType['app'], 'on'>,
-      };
-      await processExecuteCalls(electron);
-      await mock.mockRejectedValue('default mock rejected value');
-      await mock.mockRejectedValueOnce('first mock rejected value');
-      await mock.mockRejectedValueOnce('second mock rejected value');
-      await processExecuteCalls(electron);
-
-      await expect(async () => await electron.app.getFileIcon('/path/to/icon')).rejects.toThrow(
-        'first mock rejected value',
-      );
-      await expect(async () => await electron.app.getFileIcon('/path/to/icon')).rejects.toThrow(
-        'second mock rejected value',
-      );
-      await expect(async () => await electron.app.getFileIcon('/path/to/icon')).rejects.toThrow(
-        'default mock rejected value',
-      );
-    });
-  });
-
-  describe('mockClear', () => {
-    it('should clear the inner mock', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = {
-        app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
-      };
-      await processExecuteCalls(electron);
-
-      electron.app.getName();
-      electron.app.getName();
-      electron.app.getName();
-
-      expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[], [], []]);
-
-      await mock.mockClear();
-      await processExecuteCalls(electron);
-
-      expect((electron.app.getName as Mock).mock.calls).toStrictEqual([]);
-    });
-  });
-
-  describe('mockReset', () => {
-    it('should reset the inner mock', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = {
-        app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
-      };
-      await processExecuteCalls(electron);
-      await mock.mockImplementation(() => 'mocked name');
-      await processExecuteCalls(electron);
-
-      expect(electron.app.getName()).toBe('mocked name');
-      expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[]]);
-
-      await mock.mockReset();
-      await processExecuteCalls(electron);
-
-      expect(electron.app.getName()).toBeUndefined();
-      expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[]]);
-    });
-  });
-
-  describe('mockRestore', () => {
-    it('should restore the inner mock', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = {
-        app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
-      };
-      globalThis.originalApi = {
-        app: { getName: () => 'actual name' },
-      } as ElectronType;
-      await processExecuteCalls(electron);
-
-      expect(electron.app.getName()).toBeUndefined();
-      expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[]]);
-
-      await mock.mockRestore();
-      await processExecuteCalls(electron);
-
-      expect(electron.app.getName()).toBe('actual name');
-      expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[]]);
-    });
-  });
-
-  describe('mockReturnThis', () => {
-    it('should allow chaining', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = {
-        app: { getName: () => 'actual name', getVersion: () => 'actual version' } as unknown as Omit<
-          ElectronType['app'],
-          'on'
-        >,
-      };
-      await processExecuteCalls(electron);
-      await mock.mockReturnThis();
-      await processExecuteCalls(electron);
-
-      expect((electron.app.getName() as unknown as Omit<ElectronType['app'], 'on'>).getVersion()).toBe(
-        'actual version',
-      );
-    });
-  });
-
-  describe('withImplementation', () => {
-    it('should temporarily override mock implementation with sync callback', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = {
-        app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
-      };
-      await processExecuteCalls(electron);
-      await mock.withImplementation(
-        () => 'temporary name',
-        (electron) => electron.app.getName(),
-      );
-      const executeResults = await processExecuteCalls(electron);
-
-      expect(executeResults).toStrictEqual(['temporary name']);
     });
 
-    it('should temporarily override mock implementation with async callback', async () => {
-      const mock = await createMock('app', 'getName');
-      const electron = {
-        app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
-      };
-      await processExecuteCalls(electron);
-      await mock.withImplementation(
-        () => 'temporary name',
-        async (electron) => electron.app.getName(),
-      );
-      const executeResults = await processExecuteCalls(electron);
+    describe('mockClear', () => {
+      it('should clear the inner mock', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = {
+          app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
+        };
+        await processExecuteCalls(electron);
 
-      expect(executeResults).toStrictEqual(['temporary name']);
+        electron.app.getName();
+        electron.app.getName();
+        electron.app.getName();
+
+        expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[], [], []]);
+
+        await mock.mockClear();
+        await processExecuteCalls(electron);
+
+        expect((electron.app.getName as Mock).mock.calls).toStrictEqual([]);
+      });
+    });
+
+    describe('mockReset', () => {
+      it('should reset the inner mock', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = {
+          app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
+        };
+        await processExecuteCalls(electron);
+        await mock.mockImplementation(() => 'mocked name');
+        await processExecuteCalls(electron);
+
+        expect(electron.app.getName()).toBe('mocked name');
+        expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[]]);
+
+        await mock.mockReset();
+        await processExecuteCalls(electron);
+
+        expect(electron.app.getName()).toBeUndefined();
+        expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[]]);
+      });
+    });
+
+    describe('mockRestore', () => {
+      it('should restore the inner mock', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = {
+          app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
+        };
+        globalThis.originalApi = {
+          app: { getName: () => 'actual name' },
+        } as ElectronType;
+        await processExecuteCalls(electron);
+
+        expect(electron.app.getName()).toBeUndefined();
+        expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[]]);
+
+        await mock.mockRestore();
+        await processExecuteCalls(electron);
+
+        expect(electron.app.getName()).toBe('actual name');
+        expect((electron.app.getName as Mock).mock.calls).toStrictEqual([[]]);
+      });
+    });
+
+    describe('mockReturnThis', () => {
+      it('should allow chaining', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = {
+          app: { getName: () => 'actual name', getVersion: () => 'actual version' } as unknown as Omit<
+            ElectronType['app'],
+            'on'
+          >,
+        };
+        await processExecuteCalls(electron);
+        await mock.mockReturnThis();
+        await processExecuteCalls(electron);
+
+        expect((electron.app.getName() as unknown as Omit<ElectronType['app'], 'on'>).getVersion()).toBe(
+          'actual version',
+        );
+      });
+    });
+
+    describe('withImplementation', () => {
+      it('should temporarily override mock implementation with sync callback', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = {
+          app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
+        };
+        await processExecuteCalls(electron);
+        await mock.withImplementation(
+          () => 'temporary name',
+          (electron) => electron.app.getName(),
+        );
+        const executeResults = await processExecuteCalls(electron);
+
+        expect(executeResults).toStrictEqual(['temporary name']);
+      });
+
+      it('should temporarily override mock implementation with async callback', async () => {
+        const mock = await createMock('app', 'getName');
+        const electron = {
+          app: { getName: () => 'actual name' } as unknown as Omit<ElectronType['app'], 'on'>,
+        };
+        await processExecuteCalls(electron);
+        await mock.withImplementation(
+          () => 'temporary name',
+          async (electron) => electron.app.getName(),
+        );
+        const executeResults = await processExecuteCalls(electron);
+
+        expect(executeResults).toStrictEqual(['temporary name']);
+      });
     });
   });
 });

--- a/packages/wdio-electron-service/test/mockStore.spec.ts
+++ b/packages/wdio-electron-service/test/mockStore.spec.ts
@@ -12,7 +12,7 @@ afterEach(() => {
   vi.resetModules();
 });
 
-describe('get/setMock', () => {
+describe('Mock Store', () => {
   const testMock = { getMockName: () => 'test mock' } as unknown as ElectronMock;
 
   it('should set and get a specific mock', () => {

--- a/packages/wdio-electron-service/test/preload.spec.ts
+++ b/packages/wdio-electron-service/test/preload.spec.ts
@@ -13,7 +13,7 @@ vi.mock('electron', () => ({
   ipcRenderer: { invoke: ipcRendererInvokeMock },
 }));
 
-describe('preload', () => {
+describe('Preload Script', () => {
   beforeEach(async () => {
     await import('../src/preload.js');
   });

--- a/packages/wdio-electron-service/test/service.spec.ts
+++ b/packages/wdio-electron-service/test/service.spec.ts
@@ -24,80 +24,33 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('before', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+describe('Electron Worker Service', () => {
+  describe('before()', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
 
-  it('should add commands to the browser object', async () => {
-    instance = new WorkerService();
-
-    window.wdioElectron = {
-      execute: vi.fn(),
-    };
-
-    const browser = {
-      waitUntil: vi.fn().mockImplementation(async (condition) => {
-        await condition();
-      }),
-      execute: vi.fn().mockImplementation((fn) => fn()),
-      getWindowHandles: vi.fn().mockResolvedValue(['dummy']),
-      switchToWindow: vi.fn(),
-      getPuppeteer: vi.fn(),
-      electron: {}, // Let the service initialize this
-    } as unknown as WebdriverIO.Browser;
-
-    await instance.before({}, [], browser);
-
-    const serviceApi = browser.electron as BrowserExtension['electron'];
-    expect(serviceApi.clearAllMocks).toEqual(expect.any(Function));
-    expect(serviceApi.execute).toEqual(expect.any(Function));
-    expect(serviceApi.mock).toEqual(expect.any(Function));
-    expect(serviceApi.mockAll).toEqual(expect.any(Function));
-    expect(serviceApi.resetAllMocks).toEqual(expect.any(Function));
-    expect(serviceApi.restoreAllMocks).toEqual(expect.any(Function));
-  });
-
-  describe('when multiremote', () => {
-    it('should add commands to the browser object', async () => {
+    it('should add electron commands to the browser object', async () => {
       instance = new WorkerService();
-      const electronInstance = {
-        requestedCapabilities: {
-          alwaysMatch: {
-            'browserName': 'electron',
-            'wdio:electronServiceOptions': {},
-          },
-        },
+
+      window.wdioElectron = {
+        execute: vi.fn(),
+      };
+
+      const browser = {
         waitUntil: vi.fn().mockImplementation(async (condition) => {
           await condition();
         }),
-        execute: vi.fn().mockResolvedValue(true),
+        execute: vi.fn().mockImplementation((fn) => fn()),
         getWindowHandles: vi.fn().mockResolvedValue(['dummy']),
         switchToWindow: vi.fn(),
         getPuppeteer: vi.fn(),
         electron: {}, // Let the service initialize this
       } as unknown as WebdriverIO.Browser;
 
-      const browser = {
-        instances: ['electron'],
-        getInstance: (name: string) => (name === 'electron' ? electronInstance : undefined),
-        execute: vi.fn().mockResolvedValue(true),
-        isMultiremote: true,
-      } as unknown as WebdriverIO.MultiRemoteBrowser;
-
       await instance.before({}, [], browser);
 
-      // expect electron is set to root browser
-      const rootServiceApi = browser.electron;
-      expect(rootServiceApi.clearAllMocks).toEqual(expect.any(Function));
-      expect(rootServiceApi.execute).toEqual(expect.any(Function));
-      expect(rootServiceApi.mock).toEqual(expect.any(Function));
-      expect(rootServiceApi.mockAll).toEqual(expect.any(Function));
-      expect(rootServiceApi.resetAllMocks).toEqual(expect.any(Function));
-      expect(rootServiceApi.restoreAllMocks).toEqual(expect.any(Function));
-
-      // expect electron is set to electron browser
-      const serviceApi = electronInstance.electron;
+      const serviceApi = browser.electron as BrowserExtension['electron'];
       expect(serviceApi.clearAllMocks).toEqual(expect.any(Function));
       expect(serviceApi.execute).toEqual(expect.any(Function));
       expect(serviceApi.mock).toEqual(expect.any(Function));
@@ -106,163 +59,212 @@ describe('before', () => {
       expect(serviceApi.restoreAllMocks).toEqual(expect.any(Function));
     });
 
-    it('should continue when not electron Capabilities was passed', async () => {
-      instance = new WorkerService();
-      const electronInstance = {
-        requestedCapabilities: {
-          browserName: 'chrome',
-        },
-        waitUntil: vi.fn().mockImplementation(async (condition) => {
-          await condition();
-        }),
-        execute: vi.fn().mockResolvedValue(true),
-        getWindowHandles: vi.fn().mockResolvedValue(['dummy']),
-        switchToWindow: vi.fn(),
-        getPuppeteer: vi.fn(),
-        electron: {}, // Let the service initialize this
-      } as unknown as WebdriverIO.Browser;
+    describe('when multiremote', () => {
+      it('should add electron commands to the browser object', async () => {
+        instance = new WorkerService();
+        const electronInstance = {
+          requestedCapabilities: {
+            alwaysMatch: {
+              'browserName': 'electron',
+              'wdio:electronServiceOptions': {},
+            },
+          },
+          waitUntil: vi.fn().mockImplementation(async (condition) => {
+            await condition();
+          }),
+          execute: vi.fn().mockResolvedValue(true),
+          getWindowHandles: vi.fn().mockResolvedValue(['dummy']),
+          switchToWindow: vi.fn(),
+          getPuppeteer: vi.fn(),
+          electron: {}, // Let the service initialize this
+        } as unknown as WebdriverIO.Browser;
 
-      const browser = {
-        instances: ['electron'],
-        getInstance: (name: string) => (name === 'electron' ? electronInstance : undefined),
-        execute: vi.fn().mockResolvedValue(true),
-        isMultiremote: true,
-      } as unknown as WebdriverIO.MultiRemoteBrowser;
+        const browser = {
+          instances: ['electron'],
+          getInstance: (name: string) => (name === 'electron' ? electronInstance : undefined),
+          execute: vi.fn().mockResolvedValue(true),
+          isMultiremote: true,
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
 
-      await instance.before({}, [], browser);
+        await instance.before({}, [], browser);
 
-      // expect electron is not set to electron browser
-      const serviceApi = electronInstance.electron;
+        // expect electron is set to root browser
+        const rootServiceApi = browser.electron;
+        expect(rootServiceApi.clearAllMocks).toEqual(expect.any(Function));
+        expect(rootServiceApi.execute).toEqual(expect.any(Function));
+        expect(rootServiceApi.mock).toEqual(expect.any(Function));
+        expect(rootServiceApi.mockAll).toEqual(expect.any(Function));
+        expect(rootServiceApi.resetAllMocks).toEqual(expect.any(Function));
+        expect(rootServiceApi.restoreAllMocks).toEqual(expect.any(Function));
 
-      expect(serviceApi).toStrictEqual({});
+        // expect electron is set to electron browser
+        const serviceApi = electronInstance.electron;
+        expect(serviceApi.clearAllMocks).toEqual(expect.any(Function));
+        expect(serviceApi.execute).toEqual(expect.any(Function));
+        expect(serviceApi.mock).toEqual(expect.any(Function));
+        expect(serviceApi.mockAll).toEqual(expect.any(Function));
+        expect(serviceApi.resetAllMocks).toEqual(expect.any(Function));
+        expect(serviceApi.restoreAllMocks).toEqual(expect.any(Function));
+      });
+
+      it('should continue with non-electron capabilities', async () => {
+        instance = new WorkerService();
+        const electronInstance = {
+          requestedCapabilities: {
+            browserName: 'chrome',
+          },
+          waitUntil: vi.fn().mockImplementation(async (condition) => {
+            await condition();
+          }),
+          execute: vi.fn().mockResolvedValue(true),
+          getWindowHandles: vi.fn().mockResolvedValue(['dummy']),
+          switchToWindow: vi.fn(),
+          getPuppeteer: vi.fn(),
+          electron: {}, // Let the service initialize this
+        } as unknown as WebdriverIO.Browser;
+
+        const browser = {
+          instances: ['electron'],
+          getInstance: (name: string) => (name === 'electron' ? electronInstance : undefined),
+          execute: vi.fn().mockResolvedValue(true),
+          isMultiremote: true,
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await instance.before({}, [], browser);
+
+        // expect electron is not set to electron browser
+        const serviceApi = electronInstance.electron;
+
+        expect(serviceApi).toStrictEqual({});
+      });
     });
   });
-});
 
-describe('beforeTest', () => {
-  vi.mock('../src/commands/clearAllMocks.js', () => ({
-    clearAllMocks: vi.fn().mockReturnValue({}),
-  }));
-  vi.mock('../src/commands/resetAllMocks.js', () => ({
-    resetAllMocks: vi.fn().mockReturnValue({}),
-  }));
-  vi.mock('../src/commands/restoreAllMocks.js', () => ({
-    restoreAllMocks: vi.fn().mockReturnValue({}),
-  }));
+  describe('beforeTest()', () => {
+    vi.mock('../src/commands/clearAllMocks.js', () => ({
+      clearAllMocks: vi.fn().mockReturnValue({}),
+    }));
+    vi.mock('../src/commands/resetAllMocks.js', () => ({
+      resetAllMocks: vi.fn().mockReturnValue({}),
+    }));
+    vi.mock('../src/commands/restoreAllMocks.js', () => ({
+      restoreAllMocks: vi.fn().mockReturnValue({}),
+    }));
 
-  const browser = {
-    waitUntil: vi.fn().mockImplementation(async (condition) => {
-      await condition();
-    }),
-    execute: vi.fn().mockResolvedValue(true),
-    getPuppeteer: vi.fn(),
-    getWindowHandles: vi.fn().mockResolvedValue(['dummy']),
-  } as unknown as WebdriverIO.Browser;
+    const browser = {
+      waitUntil: vi.fn().mockImplementation(async (condition) => {
+        await condition();
+      }),
+      execute: vi.fn().mockResolvedValue(true),
+      getPuppeteer: vi.fn(),
+      getWindowHandles: vi.fn().mockResolvedValue(['dummy']),
+    } as unknown as WebdriverIO.Browser;
 
-  it.each([
-    [`clearMocks`, clearAllMocks],
-    [`resetMocks`, resetAllMocks],
-    [`restoreMocks`, restoreAllMocks],
-  ])('should clear all mocks when `%s` is set', async (option, fn) => {
-    instance = new WorkerService({ [option]: true });
-    await instance.before({}, [], browser);
-    await instance.beforeTest();
-
-    expect(fn).toHaveBeenCalled();
-  });
-
-  describe('when setting options in capabilities', () => {
     it.each([
       [`clearMocks`, clearAllMocks],
       [`resetMocks`, resetAllMocks],
       [`restoreMocks`, restoreAllMocks],
-    ])('should clear all mocks when `%s` is set in capabilities', async (option, fn) => {
-      instance = new WorkerService();
-      await instance.before({ 'wdio:electronServiceOptions': { [option]: true } }, [], browser);
+    ])('should clear all mocks when `%s` is set', async (option, fn) => {
+      instance = new WorkerService({ [option]: true });
+      await instance.before({}, [], browser);
       await instance.beforeTest();
 
       expect(fn).toHaveBeenCalled();
     });
-  });
-});
 
-describe('beforeCommand', () => {
-  const browser = {
-    waitUntil: vi.fn().mockImplementation(async (condition) => {
-      await condition();
-    }),
-    execute: vi.fn().mockResolvedValue(true),
-    getPuppeteer: vi.fn(),
-    getWindowHandles: vi.fn().mockResolvedValue(['dummy']),
-  } as unknown as WebdriverIO.Browser;
+    describe('when setting options in capabilities', () => {
+      it.each([
+        [`clearMocks`, clearAllMocks],
+        [`resetMocks`, resetAllMocks],
+        [`restoreMocks`, restoreAllMocks],
+      ])('should clear all mocks when `%s` is set in capabilities', async (option, fn) => {
+        instance = new WorkerService();
+        await instance.before({ 'wdio:electronServiceOptions': { [option]: true } }, [], browser);
+        await instance.beforeTest();
 
-  beforeEach(() => {
-    vi.mocked(ensureActiveWindowFocus).mockClear();
-  });
-
-  it('should call `ensureActiveWindowFocus`', async () => {
-    instance = new WorkerService();
-    await instance.before({}, [], browser);
-    await instance.beforeCommand('dummyCommand', []);
-
-    expect(ensureActiveWindowFocus).toHaveBeenCalledWith(browser, 'dummyCommand', undefined);
+        expect(fn).toHaveBeenCalled();
+      });
+    });
   });
 
-  it('should not call `ensureActiveWindowFocus` when excluded command', async () => {
-    instance = new WorkerService();
-    await instance.before({}, [], browser);
-    await instance.beforeCommand('getWindowHandles', []);
+  describe('beforeCommand()', () => {
+    const browser = {
+      waitUntil: vi.fn().mockImplementation(async (condition) => {
+        await condition();
+      }),
+      execute: vi.fn().mockResolvedValue(true),
+      getPuppeteer: vi.fn(),
+      getWindowHandles: vi.fn().mockResolvedValue(['dummy']),
+    } as unknown as WebdriverIO.Browser;
 
-    expect(ensureActiveWindowFocus).toHaveBeenCalledTimes(0);
-  });
-});
+    beforeEach(() => {
+      vi.mocked(ensureActiveWindowFocus).mockClear();
+    });
 
-describe('afterCommand', () => {
-  let mocks: [string, ElectronMock][] = [];
+    it('should call `ensureActiveWindowFocus` for all commands', async () => {
+      instance = new WorkerService();
+      await instance.before({}, [], browser);
+      await instance.beforeCommand('dummyCommand', []);
 
-  vi.mock('../src/mockStore', () => ({
-    default: {
-      getMocks: vi.fn(),
-    },
-  }));
+      expect(ensureActiveWindowFocus).toHaveBeenCalledWith(browser, 'dummyCommand', undefined);
+    });
 
-  beforeEach(() => {
-    (mockStore.getMocks as Mock).mockImplementation(() => mocks);
-  });
+    it('should not call `ensureActiveWindowFocus` for excluded commands', async () => {
+      instance = new WorkerService();
+      await instance.before({}, [], browser);
+      await instance.beforeCommand('getWindowHandles', []);
 
-  it.each(['deleteSession'])('should not update mocks when the command is %s', async (commandName: string) => {
-    instance = new WorkerService();
-    mocks = [
-      ['electron.app.getName', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
-      ['electron.app.getVersion', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
-    ];
-    await instance.afterCommand(commandName, [['look', 'some', 'args']]);
-
-    expect(mocks[0][1].update).not.toHaveBeenCalled();
-    expect(mocks[1][1].update).not.toHaveBeenCalled();
+      expect(ensureActiveWindowFocus).toHaveBeenCalledTimes(0);
+    });
   });
 
-  it('should not update mocks when the command is `execute` and internal is set', async () => {
-    instance = new WorkerService();
-    mocks = [
-      ['electron.app.getName', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
-      ['electron.app.getVersion', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
-    ];
-    await instance.afterCommand('execute', [['look', 'some', 'args'], { internal: true }]);
+  describe('afterCommand()', () => {
+    let mocks: [string, ElectronMock][] = [];
 
-    expect(mocks[0][1].update).not.toHaveBeenCalled();
-    expect(mocks[1][1].update).not.toHaveBeenCalled();
-  });
+    vi.mock('../src/mockStore', () => ({
+      default: {
+        getMocks: vi.fn(),
+      },
+    }));
 
-  it('should update mocks when the command is `execute` and internal is not set', async () => {
-    instance = new WorkerService();
-    mocks = [
-      ['electron.app.getName', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
-      ['electron.app.getVersion', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
-    ];
-    await instance.afterCommand('execute', [['look', 'some', 'args']]);
+    beforeEach(() => {
+      (mockStore.getMocks as Mock).mockImplementation(() => mocks);
+    });
 
-    expect(mocks[0][1].update).toHaveBeenCalled();
-    expect(mocks[1][1].update).toHaveBeenCalled();
+    it.each(['deleteSession'])('should not update mocks when the command is %s', async (commandName: string) => {
+      instance = new WorkerService();
+      mocks = [
+        ['electron.app.getName', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
+        ['electron.app.getVersion', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
+      ];
+      await instance.afterCommand(commandName, [['look', 'some', 'args']]);
+
+      expect(mocks[0][1].update).not.toHaveBeenCalled();
+      expect(mocks[1][1].update).not.toHaveBeenCalled();
+    });
+
+    it('should not update mocks when the command is `execute` and internal is set', async () => {
+      instance = new WorkerService();
+      mocks = [
+        ['electron.app.getName', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
+        ['electron.app.getVersion', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
+      ];
+      await instance.afterCommand('execute', [['look', 'some', 'args'], { internal: true }]);
+
+      expect(mocks[0][1].update).not.toHaveBeenCalled();
+      expect(mocks[1][1].update).not.toHaveBeenCalled();
+    });
+
+    it('should update mocks when the command is `execute` and internal is not set', async () => {
+      instance = new WorkerService();
+      mocks = [
+        ['electron.app.getName', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
+        ['electron.app.getVersion', { update: vi.fn().mockResolvedValue({}) } as unknown as ElectronMock],
+      ];
+      await instance.afterCommand('execute', [['look', 'some', 'args']]);
+
+      expect(mocks[0][1].update).toHaveBeenCalled();
+      expect(mocks[1][1].update).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/wdio-electron-service/test/session.spec.ts
+++ b/packages/wdio-electron-service/test/session.spec.ts
@@ -24,64 +24,66 @@ vi.mock('../src/launcher.js', () => ({
 }));
 vi.mock('webdriverio', () => ({ remote: async () => Promise.resolve(browserMock) }));
 
-describe('init', () => {
-  beforeAll(() => {
-    vi.clearAllMocks();
-  });
-  it('should create a new browser session', async () => {
-    const session = await init({});
-    expect(session).toStrictEqual(browserMock);
-  });
-
-  it('should call onPrepare with the expected parameters', async () => {
-    await init([
-      {
-        'browserName': 'electron',
-        'browserVersion': '99.9.9',
-        'wdio:electronServiceOptions': {
-          appBinaryPath: '/path/to/binary',
-        },
-        'goog:chromeOptions': {
-          args: ['--disable-dev-shm-usage', '--disable-gpu', '--headless'],
-        },
-        'wdio:chromedriverOptions': {
-          binary: '/path/to/chromedriver',
-        },
-      },
-    ]);
-    expect(onPrepareMock).toHaveBeenCalledWith({}, [
-      {
-        'browserName': 'electron',
-        'browserVersion': '99.9.9',
-        'wdio:electronServiceOptions': {
-          appBinaryPath: '/path/to/binary',
-        },
-        'goog:chromeOptions': {
-          args: ['--disable-dev-shm-usage', '--disable-gpu', '--headless'],
-        },
-        'wdio:chromedriverOptions': {
-          binary: '/path/to/chromedriver',
-        },
-      },
-    ]);
-  });
-
-  it('should call onPrepare with the expected parameters when a rootDir is specified', async () => {
-    await init([{ 'browserName': 'electron', 'wdio:electronServiceOptions': { appBinaryPath: '/path/to/binary' } }], {
-      rootDir: '/path/to/root',
+describe('Session Management', () => {
+  describe('init()', () => {
+    beforeAll(() => {
+      vi.clearAllMocks();
     });
-    expect(onPrepareMock).toHaveBeenCalledWith({ rootDir: '/path/to/root' }, [
-      {
-        'browserName': 'electron',
-        'wdio:electronServiceOptions': {
-          appBinaryPath: '/path/to/binary',
-        },
-      },
-    ]);
-  });
+    it('should create a new browser session', async () => {
+      const session = await init({});
+      expect(session).toStrictEqual(browserMock);
+    });
 
-  it('should call before with the expected parameters', async () => {
-    await init([{ 'wdio:electronServiceOptions': { appBinaryPath: '/path/to/binary' } }]);
-    expect(beforeMock).toHaveBeenCalledWith({}, [], browserMock);
+    it('should call onPrepare with the expected parameters', async () => {
+      await init([
+        {
+          'browserName': 'electron',
+          'browserVersion': '99.9.9',
+          'wdio:electronServiceOptions': {
+            appBinaryPath: '/path/to/binary',
+          },
+          'goog:chromeOptions': {
+            args: ['--disable-dev-shm-usage', '--disable-gpu', '--headless'],
+          },
+          'wdio:chromedriverOptions': {
+            binary: '/path/to/chromedriver',
+          },
+        },
+      ]);
+      expect(onPrepareMock).toHaveBeenCalledWith({}, [
+        {
+          'browserName': 'electron',
+          'browserVersion': '99.9.9',
+          'wdio:electronServiceOptions': {
+            appBinaryPath: '/path/to/binary',
+          },
+          'goog:chromeOptions': {
+            args: ['--disable-dev-shm-usage', '--disable-gpu', '--headless'],
+          },
+          'wdio:chromedriverOptions': {
+            binary: '/path/to/chromedriver',
+          },
+        },
+      ]);
+    });
+
+    it('should call onPrepare with the expected parameters when a rootDir is specified', async () => {
+      await init([{ 'browserName': 'electron', 'wdio:electronServiceOptions': { appBinaryPath: '/path/to/binary' } }], {
+        rootDir: '/path/to/root',
+      });
+      expect(onPrepareMock).toHaveBeenCalledWith({ rootDir: '/path/to/root' }, [
+        {
+          'browserName': 'electron',
+          'wdio:electronServiceOptions': {
+            appBinaryPath: '/path/to/binary',
+          },
+        },
+      ]);
+    });
+
+    it('should call before with the expected parameters', async () => {
+      await init([{ 'wdio:electronServiceOptions': { appBinaryPath: '/path/to/binary' } }]);
+      expect(beforeMock).toHaveBeenCalledWith({}, [], browserMock);
+    });
   });
 });

--- a/packages/wdio-electron-service/test/versions.spec.ts
+++ b/packages/wdio-electron-service/test/versions.spec.ts
@@ -3,65 +3,67 @@ import nock from 'nock';
 
 import { getChromiumVersion } from '../src/versions.js';
 
-describe('getChromiumVersion', () => {
-  it('should find the Chromium version for a given Electron version', async () => {
-    nock('https://electronjs.org')
-      .get('/headers/index.json')
-      .reply(200, [
-        {
-          version: '25.8.3',
-          date: '2023-09-27',
-          node: '18.15.0',
-          v8: '11.4.183.29-electron.0',
-          uv: '1.44.2',
-          zlib: '1.2.13',
-          openssl: '1.1.1',
-          modules: '116',
-          chrome: '114.0.5735.289',
-          files: [
-            'darwin-x64',
-            'darwin-x64-symbols',
-            'linux-ia32',
-            'linux-ia32-symbols',
-            'linux-x64',
-            'linux-x64-symbols',
-            'win32-ia32',
-            'win32-ia32-symbols',
-            'win32-x64',
-            'win32-x64-symbols',
-          ],
-        },
-        {
-          version: '24.8.4',
-          date: '2023-09-27',
-          node: '18.14.0',
-          v8: '11.2.214.22-electron.0',
-          uv: '1.44.2',
-          zlib: '1.2.13',
-          openssl: '1.1.1',
-          modules: '114',
-          chrome: '112.0.5615.204',
-          files: [
-            'darwin-x64',
-            'darwin-x64-symbols',
-            'linux-ia32',
-            'linux-ia32-symbols',
-            'linux-x64',
-            'linux-x64-symbols',
-            'win32-ia32',
-            'win32-ia32-symbols',
-            'win32-x64',
-            'win32-x64-symbols',
-          ],
-        },
-      ]);
-    expect(await getChromiumVersion('24.8.4')).toBe('112.0.5615.204');
-    expect(await getChromiumVersion('25.8.3')).toBe('114.0.5735.289');
-  });
+describe('Version Utilities', () => {
+  describe('getChromiumVersion()', () => {
+    it('should find the Chromium version for a given Electron version', async () => {
+      nock('https://electronjs.org')
+        .get('/headers/index.json')
+        .reply(200, [
+          {
+            version: '25.8.3',
+            date: '2023-09-27',
+            node: '18.15.0',
+            v8: '11.4.183.29-electron.0',
+            uv: '1.44.2',
+            zlib: '1.2.13',
+            openssl: '1.1.1',
+            modules: '116',
+            chrome: '114.0.5735.289',
+            files: [
+              'darwin-x64',
+              'darwin-x64-symbols',
+              'linux-ia32',
+              'linux-ia32-symbols',
+              'linux-x64',
+              'linux-x64-symbols',
+              'win32-ia32',
+              'win32-ia32-symbols',
+              'win32-x64',
+              'win32-x64-symbols',
+            ],
+          },
+          {
+            version: '24.8.4',
+            date: '2023-09-27',
+            node: '18.14.0',
+            v8: '11.2.214.22-electron.0',
+            uv: '1.44.2',
+            zlib: '1.2.13',
+            openssl: '1.1.1',
+            modules: '114',
+            chrome: '112.0.5615.204',
+            files: [
+              'darwin-x64',
+              'darwin-x64-symbols',
+              'linux-ia32',
+              'linux-ia32-symbols',
+              'linux-x64',
+              'linux-x64-symbols',
+              'win32-ia32',
+              'win32-ia32-symbols',
+              'win32-x64',
+              'win32-x64-symbols',
+            ],
+          },
+        ]);
+      expect(await getChromiumVersion('24.8.4')).toBe('112.0.5615.204');
+      expect(await getChromiumVersion('25.8.3')).toBe('114.0.5735.289');
+    });
 
-  it('should fall back to the locally installed electron-to-chromium version map', async () => {
-    nock('https://electronjs.org').get('/headers/index.json').reply(400, 'Bad Request');
-    expect(await getChromiumVersion('24.8.4')).toBe('112.0.5615.204');
-    expect(await getChromiumVersion('25.8.3')).toBe('114.0.5735.289');
+    it('should fall back to the locally installed electron-to-chromium version map', async () => {
+      nock('https://electronjs.org').get('/headers/index.json').reply(400, 'Bad Request');
+      expect(await getChromiumVersion('24.8.4')).toBe('112.0.5615.204');
+      expect(await getChromiumVersion('25.8.3')).toBe('114.0.5735.289');
+    });
   });
 });

--- a/packages/wdio-electron-service/test/window.spec.ts
+++ b/packages/wdio-electron-service/test/window.spec.ts
@@ -9,175 +9,177 @@ vi.mock('@wdio/electron-utils/log', () => ({
   },
 }));
 
-describe('getWindowHandle', () => {
-  describe('when no window', () => {
-    it('should return undefined when no windows are available', async () => {
-      const puppeteerBrowser = {
-        targets: vi.fn().mockReturnValue([]),
-      } as unknown as PuppeteerBrowser;
+describe('Window Management', () => {
+  describe('getActiveWindowHandle()', () => {
+    describe('when no window', () => {
+      it('should return undefined when no windows are available', async () => {
+        const puppeteerBrowser = {
+          targets: vi.fn().mockReturnValue([]),
+        } as unknown as PuppeteerBrowser;
 
-      const handle = await getActiveWindowHandle(puppeteerBrowser);
-      expect(handle).toBe(undefined);
+        const handle = await getActiveWindowHandle(puppeteerBrowser);
+        expect(handle).toBe(undefined);
+      });
+    });
+
+    describe('when 1 window', () => {
+      it('should return the active window handle', async () => {
+        const puppeteerBrowser = {
+          targets: vi.fn().mockReturnValue([
+            {
+              type: vi.fn().mockReturnValue('page'),
+              _targetId: 'window-1',
+            },
+          ]),
+        } as unknown as PuppeteerBrowser;
+
+        const handle = await getActiveWindowHandle(puppeteerBrowser);
+        expect(handle).toBe('window-1');
+      });
+    });
+
+    describe('when 2 or more windows', () => {
+      it('should return the current window handle when active', async () => {
+        const puppeteerBrowser = {
+          targets: vi.fn().mockReturnValue([
+            {
+              type: vi.fn().mockReturnValue('page'),
+              _targetId: 'window-1',
+            },
+            {
+              type: vi.fn().mockReturnValue('page'),
+              _targetId: 'window-2',
+            },
+          ]),
+        } as unknown as PuppeteerBrowser;
+
+        const handle = await getActiveWindowHandle(puppeteerBrowser, 'window-1');
+        expect(handle).toBe('window-1');
+      });
+
+      it('should fallback to the first window handle when current is invalid', async () => {
+        const puppeteerBrowser = {
+          targets: vi.fn().mockReturnValue([
+            {
+              type: vi.fn().mockReturnValue('page'),
+              _targetId: 'window-1',
+            },
+            {
+              type: vi.fn().mockReturnValue('page'),
+              _targetId: 'window-2',
+            },
+          ]),
+        } as unknown as PuppeteerBrowser;
+
+        const handle = await getActiveWindowHandle(puppeteerBrowser, 'invalid-window');
+        expect(handle).toBe('window-1');
+      });
     });
   });
 
-  describe('when 1 window', () => {
-    it('should return the active window handle', async () => {
-      const puppeteerBrowser = {
-        targets: vi.fn().mockReturnValue([
-          {
-            type: vi.fn().mockReturnValue('page'),
-            _targetId: 'window-1',
-          },
-        ]),
-      } as unknown as PuppeteerBrowser;
-
-      const handle = await getActiveWindowHandle(puppeteerBrowser);
-      expect(handle).toBe('window-1');
-    });
-  });
-
-  describe('when 2 or more windows', () => {
-    it('should return the current window handle when active', async () => {
-      const puppeteerBrowser = {
-        targets: vi.fn().mockReturnValue([
-          {
-            type: vi.fn().mockReturnValue('page'),
-            _targetId: 'window-1',
-          },
-          {
-            type: vi.fn().mockReturnValue('page'),
-            _targetId: 'window-2',
-          },
-        ]),
-      } as unknown as PuppeteerBrowser;
-
-      const handle = await getActiveWindowHandle(puppeteerBrowser, 'window-1');
-      expect(handle).toBe('window-1');
+  describe('ensureActiveWindowFocus()', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
     });
 
-    it('should fallback to the first window handle when current is invalid', async () => {
-      const puppeteerBrowser = {
-        targets: vi.fn().mockReturnValue([
-          {
-            type: vi.fn().mockReturnValue('page'),
-            _targetId: 'window-1',
-          },
-          {
-            type: vi.fn().mockReturnValue('page'),
-            _targetId: 'window-2',
-          },
-        ]),
-      } as unknown as PuppeteerBrowser;
-
-      const handle = await getActiveWindowHandle(puppeteerBrowser, 'invalid-window');
-      expect(handle).toBe('window-1');
-    });
-  });
-});
-
-describe('ensureActiveWindowFocus', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('should switch focus to the new window when it becomes active', async () => {
-    const switchToWindowMock = vi.fn();
-    const browser = {
-      isMultiremote: false,
-      electron: {
-        windowHandle: 'currentWindow',
-      },
-      switchToWindow: switchToWindowMock,
-    } as unknown as WebdriverIO.Browser;
-    const puppeteerBrowser = {
-      targets: vi.fn().mockReturnValue([
-        {
-          type: vi.fn().mockReturnValue('page'),
-          _targetId: 'window-1',
-        },
-      ]),
-    } as unknown as PuppeteerBrowser;
-    await ensureActiveWindowFocus(browser as unknown as WebdriverIO.Browser, 'dummyCommand', puppeteerBrowser);
-    expect(switchToWindowMock).toHaveBeenCalled();
-    expect(browser.electron.windowHandle).toBe('window-1');
-  });
-
-  it('should maintain focus when staying on same window', async () => {
-    const switchToWindowMock = vi.fn();
-    const browser = {
-      isMultiremote: false,
-      electron: {
-        windowHandle: 'currentWindow',
-      },
-      switchToWindow: switchToWindowMock,
-    } as unknown as WebdriverIO.Browser;
-    const puppeteerBrowser = {
-      targets: vi.fn().mockReturnValue([
-        {
-          type: vi.fn().mockReturnValue('page'),
-          _targetId: 'currentWindow',
-        },
-      ]),
-    } as unknown as PuppeteerBrowser;
-    await ensureActiveWindowFocus(browser as unknown as WebdriverIO.Browser, 'dummyCommand', puppeteerBrowser);
-    expect(switchToWindowMock).not.toHaveBeenCalled();
-    expect(browser.electron.windowHandle).toBe('currentWindow');
-  });
-
-  describe('MultiRemote', () => {
-    const getBrowser = (newWindow = 'window1', current = 'currentWindow') => {
-      const puppeteerBrowser = {
-        targets: vi.fn().mockReturnValue([
-          {
-            type: vi.fn().mockReturnValue('page'),
-            _targetId: newWindow,
-          },
-        ]),
-      };
-
+    it('should switch focus to the new window when it becomes active', async () => {
       const switchToWindowMock = vi.fn();
       const browser = {
         isMultiremote: false,
         electron: {
-          windowHandle: current,
-          execute: vi.fn(),
+          windowHandle: 'currentWindow',
         },
-        getPuppeteer: vi.fn().mockResolvedValue(puppeteerBrowser),
         switchToWindow: switchToWindowMock,
       } as unknown as WebdriverIO.Browser;
-      return { browser, switchToWindowMock };
-    };
-
-    it('should switch focus to new windows in all browser instances', async () => {
-      const { browser: browser1, switchToWindowMock: switchToWindowMock1 } = getBrowser();
-      const { browser: browser2, switchToWindowMock: switchToWindowMock2 } = getBrowser();
-      const mrBrowser = {
-        isMultiremote: true,
-        instances: ['browser1', 'browser2'],
-        getInstance: (instance: string) => (instance === 'browser1' ? browser1 : browser2),
-        electron: {
-          execute: vi.fn(),
-        },
-      } as unknown as WebdriverIO.MultiRemoteBrowser;
-
-      await ensureActiveWindowFocus(mrBrowser as unknown as WebdriverIO.Browser, 'dummyCommand');
-      expect(switchToWindowMock1).toHaveBeenCalled();
-      expect(switchToWindowMock2).toHaveBeenCalled();
+      const puppeteerBrowser = {
+        targets: vi.fn().mockReturnValue([
+          {
+            type: vi.fn().mockReturnValue('page'),
+            _targetId: 'window-1',
+          },
+        ]),
+      } as unknown as PuppeteerBrowser;
+      await ensureActiveWindowFocus(browser as unknown as WebdriverIO.Browser, 'dummyCommand', puppeteerBrowser);
+      expect(switchToWindowMock).toHaveBeenCalled();
+      expect(browser.electron.windowHandle).toBe('window-1');
     });
 
-    it('should maintain focus when windows remain unchanged', async () => {
-      const { browser: browser1, switchToWindowMock: switchToWindowMock1 } = getBrowser('currentWindow');
-      const { browser: browser2, switchToWindowMock: switchToWindowMock2 } = getBrowser('currentWindow');
+    it('should maintain focus when staying on same window', async () => {
+      const switchToWindowMock = vi.fn();
       const browser = {
-        isMultiremote: true,
-        instances: ['browser1', 'browser2'],
-        getInstance: (instance: string) => (instance === 'browser1' ? browser1 : browser2),
-      } as unknown as WebdriverIO.MultiRemoteBrowser;
+        isMultiremote: false,
+        electron: {
+          windowHandle: 'currentWindow',
+        },
+        switchToWindow: switchToWindowMock,
+      } as unknown as WebdriverIO.Browser;
+      const puppeteerBrowser = {
+        targets: vi.fn().mockReturnValue([
+          {
+            type: vi.fn().mockReturnValue('page'),
+            _targetId: 'currentWindow',
+          },
+        ]),
+      } as unknown as PuppeteerBrowser;
+      await ensureActiveWindowFocus(browser as unknown as WebdriverIO.Browser, 'dummyCommand', puppeteerBrowser);
+      expect(switchToWindowMock).not.toHaveBeenCalled();
+      expect(browser.electron.windowHandle).toBe('currentWindow');
+    });
 
-      await ensureActiveWindowFocus(browser as unknown as WebdriverIO.Browser, 'dummyCommand');
-      expect(switchToWindowMock1).not.toHaveBeenCalled();
-      expect(switchToWindowMock2).not.toHaveBeenCalled();
+    describe('MultiRemote', () => {
+      const getBrowser = (newWindow = 'window1', current = 'currentWindow') => {
+        const puppeteerBrowser = {
+          targets: vi.fn().mockReturnValue([
+            {
+              type: vi.fn().mockReturnValue('page'),
+              _targetId: newWindow,
+            },
+          ]),
+        };
+
+        const switchToWindowMock = vi.fn();
+        const browser = {
+          isMultiremote: false,
+          electron: {
+            windowHandle: current,
+            execute: vi.fn(),
+          },
+          getPuppeteer: vi.fn().mockResolvedValue(puppeteerBrowser),
+          switchToWindow: switchToWindowMock,
+        } as unknown as WebdriverIO.Browser;
+        return { browser, switchToWindowMock };
+      };
+
+      it('should switch focus to new windows in all browser instances', async () => {
+        const { browser: browser1, switchToWindowMock: switchToWindowMock1 } = getBrowser();
+        const { browser: browser2, switchToWindowMock: switchToWindowMock2 } = getBrowser();
+        const mrBrowser = {
+          isMultiremote: true,
+          instances: ['browser1', 'browser2'],
+          getInstance: (instance: string) => (instance === 'browser1' ? browser1 : browser2),
+          electron: {
+            execute: vi.fn(),
+          },
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await ensureActiveWindowFocus(mrBrowser as unknown as WebdriverIO.Browser, 'dummyCommand');
+        expect(switchToWindowMock1).toHaveBeenCalled();
+        expect(switchToWindowMock2).toHaveBeenCalled();
+      });
+
+      it('should maintain focus when windows remain unchanged', async () => {
+        const { browser: browser1, switchToWindowMock: switchToWindowMock1 } = getBrowser('currentWindow');
+        const { browser: browser2, switchToWindowMock: switchToWindowMock2 } = getBrowser('currentWindow');
+        const browser = {
+          isMultiremote: true,
+          instances: ['browser1', 'browser2'],
+          getInstance: (instance: string) => (instance === 'browser1' ? browser1 : browser2),
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await ensureActiveWindowFocus(browser as unknown as WebdriverIO.Browser, 'dummyCommand');
+        expect(switchToWindowMock1).not.toHaveBeenCalled();
+        expect(switchToWindowMock2).not.toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
Add or change following unit test cases.

- `packages/wdio-electron-service/test/launcher.spec.ts`
    eliminate duplication of test code using each

- `packages/wdio-electron-service/test/mock.spec.ts`
    add test for `mock.update` and improve the coverage

-  `packages/wdio-electron-service/test/service.spec.ts`
    Change to appropriate test content of multi remote browser and improve the coverage