### PR TITLE
fix: broken $ and $$ types

### DIFF
--- a/e2e/test/dom.spec.ts
+++ b/e2e/test/dom.spec.ts
@@ -35,10 +35,6 @@ describe('DOM', () => {
   });
 
   describe('using $', () => {
-    /**
-     * This test is to check if return value of `$` has `getAttribute` or another attributes
-     * @see https://github.com/webdriverio-community/wdio-electron-service/issues/957
-     */
     it('should determine when an element is in the document', async () => {
       const checkbox = $('[data-testid="disabled-checkbox"]');
       const type = await checkbox.getAttribute('type');
@@ -62,10 +58,6 @@ describe('DOM', () => {
 });
 
 describe('using $$', () => {
-  /**
-   * This test is to check if return value of `$$` has `getElements` or another attributes
-   * @see https://github.com/webdriverio-community/wdio-electron-service/issues/899
-   */
   it('should be able to call getElements to return values', async () => {
     const result = $$('[data-testid="disabled-checkbox"]');
     const chainedResult = await result.getElements();

--- a/e2e/test/dom.spec.ts
+++ b/e2e/test/dom.spec.ts
@@ -6,6 +6,13 @@ describe('DOM', () => {
   let screen: WebdriverIOQueries;
 
   before(() => {
+    /**
+     * This is a workaround for the issue with the `browser` object type being
+     * mismatched`.
+     * @see https://github.com/testing-library/webdriverio-testing-library/issues/51
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
     screen = setupBrowser(browser);
   });
 
@@ -28,8 +35,16 @@ describe('DOM', () => {
   });
 
   describe('using $', () => {
+    /**
+     * This test is to check if return value of `$` has `getAttribute` or another attributes
+     * @see https://github.com/webdriverio-community/wdio-electron-service/issues/957
+     */
     it('should determine when an element is in the document', async () => {
-      await expect($('[data-testid="disabled-checkbox"]')).toExist();
+      const checkbox = $('[data-testid="disabled-checkbox"]');
+      const type = await checkbox.getAttribute('type');
+
+      await expect(checkbox).toExist();
+      await expect(type).toBe('checkbox');
     });
 
     it('should determine when an element is not in the document', async () => {
@@ -47,8 +62,12 @@ describe('DOM', () => {
 });
 
 describe('using $$', () => {
+  /**
+   * This test is to check if return value of `$$` has `getElements` or another attributes
+   * @see https://github.com/webdriverio-community/wdio-electron-service/issues/899
+   */
   it('should be able to call getElements to return values', async () => {
-    const result = await $$('[data-testid="disabled-checkbox"]');
+    const result = $$('[data-testid="disabled-checkbox"]');
     const chainedResult = await result.getElements();
     expect(chainedResult.length).toBe(1);
   });

--- a/e2e/test/interaction.spec.ts
+++ b/e2e/test/interaction.spec.ts
@@ -7,6 +7,13 @@ describe('interaction', () => {
   let screen: WebdriverIOQueries;
 
   before(() => {
+    /**
+     * This is a workaround for the issue with the `browser` object type being
+     * mismatched`.
+     * @see https://github.com/testing-library/webdriverio-testing-library/issues/51
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
     screen = setupBrowser(browser);
   });
 

--- a/packages/@wdio_electron-types/src/index.ts
+++ b/packages/@wdio_electron-types/src/index.ts
@@ -6,6 +6,8 @@ import type { Capabilities, Options } from '@wdio/types';
 import type { ArchType } from 'builder-util';
 import type { PackageJson } from 'read-package-up';
 
+import type { ChainablePromiseArray, ChainablePromiseElement } from 'webdriverio';
+
 export type Fn = (...args: unknown[]) => unknown;
 export type AsyncFn = (...args: unknown[]) => Promise<unknown>;
 export type AbstractFn = Fn | AsyncFn;
@@ -666,16 +668,8 @@ export interface ElectronMock<TArgs extends unknown[] = unknown[], TReturns = un
   (...args: TArgs): TReturns;
 }
 
-type $ = (selector: unknown) => Promise<ChainableElementBase<WebdriverIO.Element> | WebdriverIO.Element>;
-type $$ = (selector: unknown) => Promise<ChainableElementArrayBase<WebdriverIO.Element[]>>;
-type ChainableElementBase<T> = T & {
-  $: $;
-};
-type ChainableElementArrayBase<T> = T & {
-  parent: Promise<WebdriverIO.Browser | WebdriverIO.Element>;
-  foundWith: string;
-  getElements: () => Promise<T>;
-};
+type $ = (selector: unknown) => ChainablePromiseElement;
+type $$ = (selector: unknown) => ChainablePromiseArray;
 
 type SelectorsBase = {
   $: $;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6026,7 +6026,7 @@ snapshots:
 
   '@electron/get@2.0.3':
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
@@ -6040,7 +6040,7 @@ snapshots:
 
   '@electron/get@3.1.0':
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
@@ -6070,7 +6070,7 @@ snapshots:
 
   '@electron/notarize@2.5.0':
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       fs-extra: 9.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
@@ -6090,7 +6090,7 @@ snapshots:
   '@electron/osx-sign@1.3.2':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -6106,7 +6106,7 @@ snapshots:
       '@electron/osx-sign': 1.3.2
       '@electron/universal': 2.0.1
       '@electron/windows-sign': 1.2.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       extract-zip: 2.0.1
       filenamify: 4.3.0
       fs-extra: 11.3.0
@@ -6147,7 +6147,7 @@ snapshots:
       '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       detect-libc: 2.0.3
       fs-extra: 10.1.0
       got: 11.8.6
@@ -6166,7 +6166,7 @@ snapshots:
     dependencies:
       '@electron/asar': 3.3.1
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       dir-compare: 4.2.0
       fs-extra: 11.3.0
       minimatch: 9.0.5
@@ -6177,7 +6177,7 @@ snapshots:
   '@electron/windows-sign@1.2.0':
     dependencies:
       cross-dirname: 0.1.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       fs-extra: 11.3.0
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
@@ -6790,7 +6790,7 @@ snapshots:
 
   '@puppeteer/browsers@2.3.0':
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -6804,7 +6804,7 @@ snapshots:
 
   '@puppeteer/browsers@2.7.1':
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -7429,7 +7429,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7723,7 +7723,7 @@ snapshots:
 
   builder-util-runtime@9.2.10:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       sax: 1.4.1
     transitivePeerDependencies:
       - supports-color
@@ -7737,7 +7737,7 @@ snapshots:
       builder-util-runtime: 9.2.10
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -8197,6 +8197,10 @@ snapshots:
       ms: 2.0.0
 
   debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.0:
     dependencies:
       ms: 2.1.3
 
@@ -8790,7 +8794,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -8907,7 +8911,7 @@ snapshots:
 
   flora-colossus@2.0.0:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - supports-color
@@ -8975,7 +8979,7 @@ snapshots:
 
   galactus@1.0.0:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       flora-colossus: 2.0.0
       fs-extra: 10.1.0
     transitivePeerDependencies:
@@ -9075,7 +9079,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9261,14 +9265,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9280,14 +9284,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10269,7 +10273,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       get-uri: 6.0.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -10453,7 +10457,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -10476,7 +10480,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.3.0
       chromium-bidi: 0.6.3(devtools-protocol@0.0.1312386)
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       devtools-protocol: 0.0.1312386
       ws: 8.18.0
     transitivePeerDependencies:
@@ -10505,7 +10509,7 @@ snapshots:
 
   read-binary-file-arch@1.0.6:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10913,7 +10917,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -10921,7 +10925,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -11062,7 +11066,7 @@ snapshots:
 
   sumchecker@3.0.1:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -11412,7 +11416,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 9.5.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
### Description
This PR changed the return type of `$` and `$$` using the type exported by the `webdriverIo`.


#### Remarks
This change will happen the type mismatch for `Browser` type between the expected one by the method `setupBrowser` of `@testing-library/webdriverio` and one of this service provides.

This issue is suspected that it is caused by type definition of testing liblary side.
So, We will ignore the type error of this method. We would like your expert FBs on the validity of this direction.

https://github.com/testing-library/webdriverio-testing-library/issues/51

close #957