### PR TITLE
chore: update configuration for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       - 'area:dependencies'
       - 'track:main'
     groups:
+      wdio-dependencies:
+        patterns:
+          - '@wdio/*'
+          - 'webdriver'
+          - 'webdriverio'
       production-dependencies:
         dependency-type: 'production'
         patterns:
@@ -25,6 +30,19 @@ updates:
       # For `electron-builder`, ignore all updates (they break things)
       - dependency-name: 'electron-builder'
         update-types: ['version-update:semver-major', 'version-update:semver-minor', 'version-update:semver-patch']
+      # For `puppeteer-core`, ignore major updates
+      - dependency-name: 'puppeteer-core'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    labels:
+      - 'area:dependencies'
+      - 'track:main'
 
   # For maintenance branch
   - package-ecosystem: npm
@@ -37,6 +55,11 @@ updates:
       - 'area:dependencies'
       - 'track:maintenance'
     groups:
+      wdio-dependencies:
+        patterns:
+          - '@wdio/*'
+          - 'webdriver'
+          - 'webdriverio'
       production-dependencies:
         dependency-type: 'production'
         patterns:
@@ -52,3 +75,17 @@ updates:
       # For `electron-builder`, ignore all updates (they break things)
       - dependency-name: 'electron-builder'
         update-types: ['version-update:semver-major', 'version-update:semver-minor', 'version-update:semver-patch']
+      # For `puppeteer-core`, ignore major updates
+      - dependency-name: 'puppeteer-core'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    target-branch: v7
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    labels:
+      - 'area:dependencies'
+      - 'track:maintenance'


### PR DESCRIPTION
Following changes is included

- `puppeteer-core` should be match peer dependencies of `webdriverio`
- grouping `wdio` because when it had some issues, we want ignore all related packages.
- add config for GitHub Actions

closes #1000