### PR TITLE
chore: remove unnecessary dep

### DIFF
--- a/packages/@wdio_electron-utils/package.json
+++ b/packages/@wdio_electron-utils/package.json
@@ -56,7 +56,6 @@
     "find-versions": "^6.0.0",
     "json5": "^2.2.3",
     "read-package-up": "^11.0.0",
-    "rollup-plugin-node-externals": "^8.0.0",
     "smol-toml": "^1.3.1",
     "tsx": "^4.19.3",
     "yaml": "^2.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,9 +518,6 @@ importers:
       read-package-up:
         specifier: ^11.0.0
         version: 11.0.0
-      rollup-plugin-node-externals:
-        specifier: ^8.0.0
-        version: 8.0.0(rollup@4.34.9)
       smol-toml:
         specifier: ^1.3.1
         version: 1.3.1


### PR DESCRIPTION
`rollup-plugin-node-externals` is used by the bundler but not by utils