### PR TITLE
test: add wait step to the interaction e2e test

### DIFF
--- a/e2e/test/interaction.spec.ts
+++ b/e2e/test/interaction.spec.ts
@@ -3,13 +3,14 @@ import { browser } from 'wdio-electron-service';
 import type { BrowserWindow } from 'electron';
 
 const waitTextOfElement = async (element: ReturnType<typeof browser.$>, expectedText: string) => {
+  // respect configuration for the timeout and interval
+  // @see https://webdriver.io/docs/api/browser/waitUntil
   return await element.waitUntil(
     async function (this: WebdriverIO.Element) {
       return (await this.getText()) === expectedText;
     },
     {
-      timeout: 5000,
-      timeoutMsg: 'Did not reach the expected value after 5s.',
+      timeoutMsg: 'Did not reach the expected value.',
     },
   );
 };

--- a/e2e/test/interaction.spec.ts
+++ b/e2e/test/interaction.spec.ts
@@ -8,8 +8,8 @@ const waitTextOfElement = async (element: ReturnType<typeof browser.$>, expected
       return (await this.getText()) === expectedText;
     },
     {
-      timeout: 1000,
-      timeoutMsg: 'expected text to be different after 1s',
+      timeout: 5000,
+      timeoutMsg: 'Did not reach the expected value after 5s.',
     },
   );
 };

--- a/e2e/test/interaction.spec.ts
+++ b/e2e/test/interaction.spec.ts
@@ -1,26 +1,23 @@
 import { expect } from '@wdio/globals';
 import { browser } from 'wdio-electron-service';
-import { setupBrowser, type WebdriverIOQueries } from '@testing-library/webdriverio';
 import type { BrowserWindow } from 'electron';
 
 describe('interaction', () => {
-  let screen: WebdriverIOQueries;
-
-  before(() => {
-    /**
-     * This is a workaround for the issue with the `browser` object type being
-     * mismatched`.
-     * @see https://github.com/testing-library/webdriverio-testing-library/issues/51
-     */
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    screen = setupBrowser(browser);
-  });
-
   describe('keyboard input', () => {
     it('should detect keyboard input', async () => {
+      const el = browser.$('.keypress-count');
       await browser.keys(['y', 'o']);
-      expect(await (await screen.getByTestId('keypress-count')).getText()).toEqual('YO');
+      await el.waitUntil(
+        async function (this: WebdriverIO.Element) {
+          return (await this.getText()) === 'YO';
+        },
+        {
+          timeout: 1000,
+          timeoutMsg: 'expected text to be different after 1s',
+        },
+      );
+
+      await expect(el).toHaveText('YO');
     });
   });
 

--- a/e2e/test/interaction.spec.ts
+++ b/e2e/test/interaction.spec.ts
@@ -2,22 +2,27 @@ import { expect } from '@wdio/globals';
 import { browser } from 'wdio-electron-service';
 import type { BrowserWindow } from 'electron';
 
+const waitTextOfElement = async (element: ReturnType<typeof browser.$>, expectedText: string) => {
+  return await element.waitUntil(
+    async function (this: WebdriverIO.Element) {
+      return (await this.getText()) === expectedText;
+    },
+    {
+      timeout: 1000,
+      timeoutMsg: 'expected text to be different after 1s',
+    },
+  );
+};
+
 describe('interaction', () => {
   describe('keyboard input', () => {
     it('should detect keyboard input', async () => {
-      const el = browser.$('.keypress-count');
+      const expectedText = 'YO';
+      const elem = browser.$('.keypress-count');
       await browser.keys(['y', 'o']);
-      await el.waitUntil(
-        async function (this: WebdriverIO.Element) {
-          return (await this.getText()) === 'YO';
-        },
-        {
-          timeout: 1000,
-          timeoutMsg: 'expected text to be different after 1s',
-        },
-      );
+      await waitTextOfElement(elem, expectedText);
 
-      await expect(el).toHaveText('YO');
+      await expect(elem).toHaveText(expectedText);
     });
   });
 
@@ -37,8 +42,12 @@ describe('interaction', () => {
         expect(biggerClickCount).toEqual('0');
         const elem = browser.$('.make-bigger');
         await elem.click();
-        biggerClickCount = await browser.$('.click-count .bigger').getText();
+
+        const biggerClickCountElem = browser.$('.click-count .bigger');
+        await waitTextOfElement(biggerClickCountElem, '1');
+        biggerClickCount = await biggerClickCountElem.getText();
         expect(biggerClickCount).toEqual('1');
+
         bounds = (await browser.electron.execute((electron) => {
           const browserWindow = electron.BrowserWindow.getAllWindows()[0] as BrowserWindow;
           return browserWindow.getBounds();
@@ -64,6 +73,12 @@ describe('interaction', () => {
         expect(bounds.height).toEqual(310);
         const elem = browser.$('.make-smaller');
         await elem.click();
+
+        const smallerClickCountElem = browser.$('.click-count .bigger');
+        await waitTextOfElement(smallerClickCountElem, '1');
+        const smallerClickCount = await smallerClickCountElem.getText();
+        expect(smallerClickCount).toEqual('1');
+
         bounds = (await browser.electron.execute((electron) => {
           const browserWindow = electron.BrowserWindow.getAllWindows()[0] as BrowserWindow;
           return browserWindow.getBounds();


### PR DESCRIPTION
To fix the flaky test, This PR proposed the changes to add a wait step before asserting the DOM text.