### PR TITLE
chore: fix to invalid group configuration for the dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,18 @@ updates:
         dependency-type: 'production'
         patterns:
           - '*'
+        exclude-patterns:
+          - '@wdio/*'
+          - 'webdriver'
+          - 'webdriverio'
       development-dependencies:
         dependency-type: 'development'
         patterns:
           - '*'
+        exclude-patterns:
+          - '@wdio/*'
+          - 'webdriver'
+          - 'webdriverio'
     ignore:
       # For all packages, ignore major updates
       - dependency-name: '*'
@@ -64,10 +72,18 @@ updates:
         dependency-type: 'production'
         patterns:
           - '*'
+        exclude-patterns:
+          - '@wdio/*'
+          - 'webdriver'
+          - 'webdriverio'
       development-dependencies:
         dependency-type: 'development'
         patterns:
           - '*'
+        exclude-patterns:
+          - '@wdio/*'
+          - 'webdriver'
+          - 'webdriverio'
     ignore:
       # For all packages, ignore major updates
       - dependency-name: '*'


### PR DESCRIPTION
If we want to group a particular package, we may need to exclude that package from the group created by `dependency-type` with `exclude-patterns`.