### PR TITLE
feat(cdp): add ability to assign the debugger port worker by worker 

### DIFF
--- a/packages/wdio-electron-service/package.json
+++ b/packages/wdio-electron-service/package.json
@@ -93,6 +93,7 @@
     "debug": "^4.4.0",
     "electron-to-chromium": "^1.5.126",
     "fast-copy": "^3.0.2",
+    "get-port": "^7.1.0",
     "puppeteer-core": "^22.15.0",
     "read-package-up": "^11.0.0",
     "tinyspy": "^4.0.0",

--- a/packages/wdio-electron-service/test/capabilities.spec.ts
+++ b/packages/wdio-electron-service/test/capabilities.spec.ts
@@ -150,13 +150,13 @@ describe('getConvertedElectronCapabilities', () => {
     },
     'wdio:electronServiceOptions': {},
   };
-  describe.each([
-    ['Standard capabilities', expectedCap, [expectedCap]],
+  describe.each<[string, RequestedCapabilities, Array<typeof expectedCap>]>([
+    ['Standard capabilities', expectedCap as Capabilities.RequestedStandaloneCapabilities, [expectedCap]],
     [
       'W3C specific capabilities',
       {
         alwaysMatch: expectedCap,
-      },
+      } as Capabilities.W3CCapabilities,
       [expectedCap],
     ],
     [
@@ -170,19 +170,17 @@ describe('getConvertedElectronCapabilities', () => {
             alwaysMatch: expectedCap,
           },
         },
-      },
+      } as Capabilities.RequestedMultiremoteCapabilities,
       [expectedCap, expectedCap],
     ],
   ])('%s', (_title, inputCap, expectedCaps) => {
     it('should return capabilities when input electron capabilities', () => {
-      // @ts-expect-error
       const caps = getConvertedElectronCapabilities(inputCap);
       expect(caps).toStrictEqual(expectedCaps);
     });
 
     it('should not return capabilities when not input electron capabilities', () => {
       removeProperty(inputCap, 'wdio:electronServiceOptions');
-      // @ts-expect-error
       const caps = getElectronCapabilities(inputCap);
       expect(caps).toStrictEqual([]);
     });

--- a/packages/wdio-electron-service/test/capabilities.spec.ts
+++ b/packages/wdio-electron-service/test/capabilities.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { getChromeOptions, getChromedriverOptions, getElectronCapabilities } from '../src/capabilities.js';
+import {
+  getChromeOptions,
+  getChromedriverOptions,
+  getConvertedElectronCapabilities,
+  getElectronCapabilities,
+} from '../src/capabilities.js';
 
 import type { Capabilities } from '@wdio/types';
 
@@ -122,6 +127,64 @@ describe('Capabilities Utilities', () => {
         const caps = getElectronCapabilities(cap);
         expect(caps).toStrictEqual([]);
       });
+    });
+  });
+});
+
+function removeProperty(obj: unknown, keyToRemove: string): unknown {
+  if (typeof obj === 'object' && obj !== null) {
+    return Object.fromEntries(
+      Object.entries(obj)
+        .filter(([key]) => key !== keyToRemove)
+        .map(([key, value]) => [key, removeProperty(value, keyToRemove)]),
+    );
+  }
+  return obj;
+}
+
+describe('getConvertedElectronCapabilities', () => {
+  const expectedCap = {
+    'browserName': 'chrome',
+    'wdio:chromedriverOptions': {
+      binary: '/path/to/chromdriver',
+    },
+    'wdio:electronServiceOptions': {},
+  };
+  describe.each([
+    ['Standard capabilities', expectedCap, [expectedCap]],
+    [
+      'W3C specific capabilities',
+      {
+        alwaysMatch: expectedCap,
+      },
+      [expectedCap],
+    ],
+    [
+      'Multiremote capabilities',
+      {
+        instanceA: {
+          capabilities: expectedCap,
+        },
+        instanceB: {
+          capabilities: {
+            alwaysMatch: expectedCap,
+          },
+        },
+      },
+      [expectedCap, expectedCap],
+    ],
+  ])('%s', (_title, inputCap, expectedCaps) => {
+    it('should return capabilities when input electron capabilities', () => {
+      // @ts-expect-error
+      const caps = getConvertedElectronCapabilities(inputCap);
+      expect(caps).toStrictEqual(expectedCaps);
+    });
+
+    it('should not return capabilities when not input electron capabilities', () => {
+      removeProperty(inputCap, 'wdio:electronServiceOptions');
+      // @ts-expect-error
+      const caps = getElectronCapabilities(inputCap);
+      expect(caps).toStrictEqual([]);
     });
   });
 });

--- a/packages/wdio-electron-service/test/launcher.spec.ts
+++ b/packages/wdio-electron-service/test/launcher.spec.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
 
-import { describe, beforeEach, afterEach, it, expect, vi, Mock } from 'vitest';
+import { describe, beforeEach, afterEach, it, expect, vi, type Mock } from 'vitest';
 import nock from 'nock';
+import getPort from 'get-port';
 import log from '@wdio/electron-utils/log';
 import type { Capabilities, Options } from '@wdio/types';
 import type { ElectronServiceOptions } from '@wdio/electron-types';
@@ -23,7 +24,6 @@ vi.mock('node:fs/promises', () => ({
     access: vi.fn().mockResolvedValue(undefined),
   },
 }));
-
 vi.mock('@wdio/electron-utils', async (importOriginal: () => Promise<Record<string, unknown>>) => {
   const actual = await importOriginal();
   return {
@@ -45,6 +45,12 @@ vi.mock('@wdio/electron-utils/log', () => ({
     error: vi.fn(),
   },
 }));
+
+vi.mock('get-port', async () => {
+  return {
+    default: vi.fn(),
+  };
+});
 
 beforeEach(async () => {
   mockProcessProperty('platform', 'darwin');
@@ -792,6 +798,149 @@ describe('Electron Launch Service', () => {
             },
           },
         ]);
+      });
+    });
+  });
+  describe('onWorkerStart', () => {
+    let counter = 0;
+
+    beforeEach(() => {
+      counter = 0;
+      (getPort as Mock).mockImplementation(() => {
+        return 50000 + counter++;
+      });
+    });
+
+    const baseCapability = {
+      'browserName': 'chrome',
+      'browserVersion': '116.0.5845.190',
+      'goog:chromeOptions': {
+        args: ['foo=bar'],
+        binary: 'workspace/my-test-app/out/my-test-app',
+        windowTypes: ['app', 'webview'],
+      },
+      'wdio:electronServiceOptions': {},
+      'wdio:enforceWebDriverClassic': true,
+    };
+
+    describe('Standard', () => {
+      it('should apply `--inspect` to the args of `goog:chromeOptions`', async () => {
+        instance = new ElectronLaunchService({}, {}, {});
+        const capabilities = baseCapability;
+        const expectedCaps = structuredClone(capabilities);
+        expectedCaps['goog:chromeOptions'].args.push('--inspect=localhost:50000');
+
+        await instance?.onWorkerStart('0', capabilities);
+        expect(capabilities).toStrictEqual(expectedCaps);
+      });
+
+      it('should apply `--inspect` if `goog:chromeOptions` is not set to capability', async () => {
+        instance = new ElectronLaunchService({}, {}, {});
+        const capabilities = {
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.190',
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        };
+        const expectedCaps = Object.assign({}, capabilities, {
+          ['goog:chromeOptions']: {
+            args: ['--inspect=localhost:50000'],
+          },
+        });
+        await instance?.onWorkerStart('0', capabilities);
+        expect(capabilities).toStrictEqual(expectedCaps);
+      });
+
+      it('should apply `--inspect` if `args` is not set to `goog:chromeOptions`', async () => {
+        instance = new ElectronLaunchService({}, {}, {});
+        const capabilities = {
+          'browserName': 'chrome',
+          'browserVersion': '116.0.5845.190',
+          'goog:chromeOptions': {
+            binary: 'workspace/my-test-app/out/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:electronServiceOptions': {},
+          'wdio:enforceWebDriverClassic': true,
+        };
+        const expectedCaps = Object.assign({}, capabilities, {
+          ['goog:chromeOptions']: {
+            args: ['--inspect=localhost:50000'],
+            binary: 'workspace/my-test-app/out/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+        });
+        await instance?.onWorkerStart('0', capabilities);
+        expect(capabilities).toStrictEqual(expectedCaps);
+      });
+
+      it('should throw error when error occurred', async () => {
+        instance = new ElectronLaunchService({}, {}, {});
+        (getPort as Mock).mockRejectedValue('Some error');
+        await expect(() => instance?.onWorkerStart('0', baseCapability)).rejects.toThrowError();
+      });
+    });
+
+    describe('W3C-specific', () => {
+      it('should apply `--inspect` to the args of `goog:chromeOptions`', async () => {
+        instance = new ElectronLaunchService({}, {}, {});
+        const capabilities = [
+          {
+            firstMatch: [],
+            alwaysMatch: {
+              'browserName': 'chrome',
+              'browserVersion': '116.0.5845.190',
+              'goog:chromeOptions': {
+                args: ['foo=bar'],
+                binary: 'workspace/my-test-app/dist/my-test-app',
+                windowTypes: ['app', 'webview'],
+              },
+              'wdio:electronServiceOptions': {},
+              'wdio:enforceWebDriverClassic': true,
+            },
+          },
+        ];
+        const expectedCaps = structuredClone(capabilities);
+        expectedCaps[0].alwaysMatch['goog:chromeOptions'].args.push('--inspect=localhost:50000');
+
+        await instance?.onWorkerStart('0', capabilities as WebdriverIO.Capabilities);
+        expect(capabilities).toStrictEqual(expectedCaps);
+      });
+    });
+
+    describe('Multiremote', async () => {
+      it('should apply `--inspect` to the args of `goog:chromeOptions` for the electron', async () => {
+        instance = new ElectronLaunchService({}, {}, {});
+        const capabilities = {
+          firefox: {
+            capabilities: {
+              browserName: 'firefox',
+            },
+          },
+          myElectronProject: {
+            capabilities: baseCapability,
+          },
+          chrome: {
+            capabilities: {
+              browserName: 'chrome',
+            },
+          },
+          myOtherElectronProject: {
+            capabilities: {
+              firstMatch: [],
+              alwaysMatch: baseCapability,
+            },
+          },
+        };
+
+        const expectedCaps = structuredClone(capabilities);
+        expectedCaps.myElectronProject.capabilities['goog:chromeOptions'].args.push('--inspect=localhost:50000');
+        expectedCaps.myOtherElectronProject.capabilities.alwaysMatch['goog:chromeOptions'].args.push(
+          '--inspect=localhost:50001',
+        );
+
+        await instance?.onWorkerStart('0', capabilities as WebdriverIO.Capabilities);
+        expect(capabilities).toStrictEqual(expectedCaps);
       });
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,6 +624,9 @@ importers:
       fast-copy:
         specifier: ^3.0.2
         version: 3.0.2
+      get-port:
+        specifier: ^7.1.0
+        version: 7.1.0
       puppeteer-core:
         specifier: ^22.15.0
         version: 22.15.0


### PR DESCRIPTION
To assign the debugger port, we should (re-)implement the onWorkerStart hook at launcher.ts and related modules.

(Recreate: #954)