### PR TITLE
chore: remove root `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# https://github.com/electron-userland/electron-builder/issues/8175
-virtual-store-dir-max-length=80


### PR DESCRIPTION
The root `.npmrc` is only used to apply a workaround for an old electron-builder [issue](https://github.com/electron-userland/electron-builder/issues/8175).  PNPM fixed this a while ago so we can remove it